### PR TITLE
Strip first directory of Linux openocd archive

### DIFF
--- a/tools/microsoft/openocd-0.11.0.yaml
+++ b/tools/microsoft/openocd-0.11.0.yaml
@@ -47,6 +47,7 @@ linux and x64:
   install:
     untar: https://github.com/microsoft/openocd/releases/download/ms-v0.11.0/openocd-ms-v0.11.0-linux.tar.gz
     sha256: bfa359756d0cad2d3a2fa72a8416d369960732dd25f262397b66048db7a9c570
+    strip: 1
 
   settings:
     tools:


### PR DESCRIPTION
The root directory for the Linux archive is `openocd-ms-v0.11.0-linux`.