### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoft/embedded-dev


### PR DESCRIPTION
@MrTrillian and I are experimenting with this to see if it's the right way to ensure a team is added to every PR, which will facilitate cross-repo GitHub queries for open embedded PRs.