### PR TITLE
Add vcxplat as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @microsoft/embedded-dev
+* @microsoft/embedded-dev @microsoft/vcxplat


### PR DESCRIPTION
Adding this team as an automatic optional reviewer will make it easier for developers to query for pull requests across the entire cross-platform team.