### PR TITLE
Add OpenOCD patch with better RTOS support

### DIFF
--- a/tools/microsoft/openocd-0.11.0-ms1.yaml
+++ b/tools/microsoft/openocd-0.11.0-ms1.yaml
@@ -1,0 +1,58 @@
+# OpenOCD
+# install with `ce add openocd`
+
+info:
+  id: tools/microsoft/openocd
+  version: 0.11.0-ms1
+  description: >-
+    OpenOCD provides on-chip programming and debugging support with a
+    layered architecture of JTAG interface and TAP support including:
+    (X)SVF playback to facilitate automated boundary scan and FPGA/CPLD
+    programming;
+    debug target support (e.g. ARM, MIPS): single-stepping,
+    breakpoints/watchpoints, gprof profiling, etc;
+    flash chip drivers (e.g. CFI, NAND, internal flash);
+    embedded TCL interpreter for easy scripting.
+    Several network interfaces are available for interacting with OpenOCD:
+    telnet, TCL, and GDB. The GDB server enables OpenOCD to function as a
+    "remote target" for source-level debugging of embedded systems using
+    the GNU GDB program (and the others who talk GDB protocol, e.g. IDA
+    Pro).
+    This build of OpenOCD includes additional vendor extensions from Azure
+    Sphere, Raspberry Pi, and STMicroelectronics, plus improved RTOS support.
+  summary: Free and open on-chip debugging
+
+contacts:
+  Ben McMorran:
+    email: bemcmorr@microsoft.com
+    role: [publisher, originator]
+
+  OpenOCD (upstream):
+    email: openocd-user@lists.sourceforge.net
+    role: other
+
+demands:
+  windows and x64:
+    install:
+      untar: https://github.com/microsoft/openocd/releases/download/ms-v0.11.0-ms1/openocd-ms-v0.11.0-ms1-i686-w64-mingw32.tar.gz
+      sha256: dabe82ecc1aa1b1aa6d28216ee74d5702b9147fc74796990e14a7fa5644744a1
+
+    settings:
+      tools:
+        openocd: bin/openocd.exe
+
+      paths:
+        path: bin
+
+  linux and x64:
+    install:
+      untar: https://github.com/microsoft/openocd/releases/download/ms-v0.11.0-ms1/openocd-ms-v0.11.0-ms1-linux.tar.gz
+      sha256: e70a1405f5ffeb87d9487b49fe40171fe896fbd7d01a51b12cffdfb6d2b0501b
+      strip: 1
+
+    settings:
+      tools:
+        openocd: bin/openocd
+
+      paths:
+        path: bin


### PR DESCRIPTION
This incorporates changes from [this commit](https://github.com/microsoft/openocd/commit/e6573d0fded38bd160dd501046e682f5457959e3) to our OpenOCD fork. All changes in that commit have also been contributed and merged upstream. The changes enable ThreadX on ST-Link based devices and improve the display of thread names in IDEs.

I'm using the `-ms1` suffix instead of incrementing the patch version in SemVer because I don't want to conflict with upstream OpenOCD versioning.