### PR TITLE
Changing MSVC and Msbuild artifacts to use locations and properties

### DIFF
--- a/crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json
+++ b/crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json
+++ b/crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json
+++ b/crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json
+++ b/crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json
+++ b/crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x64_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json
+++ b/crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x64_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json
+++ b/crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json
+++ b/crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_Desktop_spectre": "."
         }
     },

--- a/crts/microsoft/desktop/arm/arm-14.28.29915.json
+++ b/crts/microsoft/desktop/arm/arm-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/arm/arm-14.29.30037.json
+++ b/crts/microsoft/desktop/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/arm64/arm64-14.28.29915.json
+++ b/crts/microsoft/desktop/arm64/arm64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/arm64/arm64-14.29.30037.json
+++ b/crts/microsoft/desktop/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/desktop-14.29.30037.json
+++ b/crts/microsoft/desktop/desktop-14.29.30037.json
@@ -1,39 +1,59 @@
 {
-    "info": {
-        "id": "crts/microsoft/desktop",
-        "version": "14.29.30037",
-        "summary": "MSVC standard library libraries (desktop / kernel32)"
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "demands": {
-        "target:x86": {
-            "requires": {
-                "crts/microsoft/desktop/x86": "14.29.30037",
-                "crts/microsoft/onecore/x86": "14.29.30037"
-            }
-        },
-        "target:x64": {
-            "requires": {
-                "crts/microsoft/desktop/x64": "14.29.30037",
-                "crts/microsoft/onecore/x64": "14.29.30037"
-            }
-        },
-        "target:arm": {
-            "requires": {
-                "crts/microsoft/desktop/arm": "14.29.30037",
-                "crts/microsoft/onecore/arm": "14.29.30037"
-            }
-        },
-        "target:arm64": {
-            "requires": {
-                "crts/microsoft/desktop/arm64": "14.29.30037",
-                "crts/microsoft/onecore/arm64": "14.29.30037"
-            }
-        }
+  "info": {
+    "id": "crts/microsoft/desktop",
+    "version": "14.29.30037",
+    "summary": "MSVC standard library libraries (desktop / kernel32)"
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "demands": {
+    "target:x86": {
+      "requires": {
+        "crts/microsoft/desktop/x86": "14.29.30037",
+        "crts/microsoft/onecore/x86": "14.29.30037"
+      },
+      "exports": {
+        "properties": {
+          "VC_LibraryPath_VC_x86": "$(VC_LibraryPath_VC_x86_Desktop);$(VC_LibraryPath_VC_x86_OneCore);$(VC_LibraryPath_VC_x86)"
+        }
+      }
+    },
+    "target:x64": {
+      "requires": {
+        "crts/microsoft/desktop/x64": "14.29.30037",
+        "crts/microsoft/onecore/x64": "14.29.30037"
+      },
+      "exports": {
+        "properties": {
+          "VC_LibraryPath_VC_x64": "$(VC_LibraryPath_VC_x64_Desktop);$(VC_LibraryPath_VC_x64_OneCore);$(VC_LibraryPath_VC_x64)"
+        }
+      }
+    },
+    "target:arm": {
+      "requires": {
+        "crts/microsoft/desktop/arm": "14.29.30037",
+        "crts/microsoft/onecore/arm": "14.29.30037"
+      },
+      "exports": {
+        "properties": {
+          "VC_LibraryPath_VC_ARM": "$(VC_LibraryPath_VC_ARM_Desktop);$(VC_LibraryPath_VC_ARM_OneCore);$(VC_LibraryPath_VC_ARM)"
+        }
+      }
+    },
+    "target:arm64": {
+      "requires": {
+        "crts/microsoft/desktop/arm64": "14.29.30037",
+        "crts/microsoft/onecore/arm64": "14.29.30037"
+      },
+      "exports": {
+        "properties": {
+          "VC_LibraryPath_VC_ARM64": "$(VC_LibraryPath_VC_ARM64_Desktop);$(VC_LibraryPath_VC_ARM64_OneCore);$(VC_LibraryPath_VC_ARM64)"
+        }
+      }
+    }
+  }
 }

--- a/crts/microsoft/desktop/x64/x64-14.28.29915.json
+++ b/crts/microsoft/desktop/x64/x64-14.28.29915.json
@@ -12,10 +12,10 @@
         }
     },
     "exports": {
-        "paths": {
-            "lib": "."
-        },
-        "environment": {
+      "paths": {
+        "lib": "."
+      },
+        "locations": {
             "VC_LibraryPath_VC_x64_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/x64/x64-14.29.30037.json
+++ b/crts/microsoft/desktop/x64/x64-14.29.30037.json
@@ -14,12 +14,12 @@
     "demands": {
         "windows": {
             "exports": {
-                "paths": {
-                    "LIB": "."
-                },
-                "environment": {
-                    "VC_LibraryPath_VC_x64_Desktop": "."
-                }
+              "paths": {
+                "LIB": "."
+              },
+              "locations": {
+                "VC_LibraryPath_VC_x64_Desktop": "."
+              }
             }
         }
     },

--- a/crts/microsoft/desktop/x86/x86-14.28.29915.json
+++ b/crts/microsoft/desktop/x86/x86-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_Desktop": "."
         }
     },

--- a/crts/microsoft/desktop/x86/x86-14.29.30037.json
+++ b/crts/microsoft/desktop/x86/x86-14.29.30037.json
@@ -1,38 +1,40 @@
 {
-    "info": {
-        "id": "crts/microsoft/desktop/x86",
-        "version": "14.29.30037",
-        "summary": "MSVC standard library libraries (desktop / kernel32)",
-        "options": [ "dependencyOnly" ]
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
+  "info": {
+    "id": "crts/microsoft/desktop/x86",
+    "version": "14.29.30037",
+    "summary": "MSVC standard library libraries (desktop / kernel32)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
+    }
+  },
+  "requires": {
+    "crts/microsoft/headers": "14.29.30037"
+  },
+  "demands": {
+    "windows": {
+      "exports": {
+        "paths": {
+          "LIB": ".",
+          "LIBPATH": "."
+        },
+        "locations": {
+          "VC_LibraryPath_VC_x86_Desktop": "."
         }
-    },
-    "requires": {
-        "crts/microsoft/headers": "14.29.30037"
-    },
-    "demands": {
-        "windows": {
-            "exports": {
-                "paths": {
-                    "LIB": ".",
-                    "LIBPATH": ".",
-                    "VC_LibraryPath_VC_x86_Desktop": "."
-                }
-            }
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.CRT.x86.Desktop.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/02b2e54551c4692d6e270c538e8008d1a9c55b1fa727bddf2126c796a64c3161/Microsoft.VC.14.29.16.10.CRT.x86.Desktop.base.vsix"
-            ],
-            "sha256": "02b2e54551c4692d6e270c538e8008d1a9c55b1fa727bddf2126c796a64c3161",
-            "strip": 7
-        }
-    ]
+      }
+    }
+  },
+  "install": [
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.CRT.x86.Desktop.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/02b2e54551c4692d6e270c538e8008d1a9c55b1fa727bddf2126c796a64c3161/Microsoft.VC.14.29.16.10.CRT.x86.Desktop.base.vsix"
+      ],
+      "sha256": "02b2e54551c4692d6e270c538e8008d1a9c55b1fa727bddf2126c796a64c3161",
+      "strip": 7
+    }
+  ]
 }

--- a/crts/microsoft/headers/headers-14.28.29912.json
+++ b/crts/microsoft/headers/headers-14.28.29912.json
@@ -14,7 +14,7 @@
         "paths": {
             "include": "."
         },
-        "environment": {
+        "locations": {
             "VC_VC_IncludePath": "."
         }
     },

--- a/crts/microsoft/headers/headers-14.29.30037.json
+++ b/crts/microsoft/headers/headers-14.29.30037.json
@@ -17,10 +17,12 @@
     "demands": {
         "windows": {
             "exports": {
-                "paths": {
-                    "INCLUDE": ".",
-                    "VC_VC_IncludePath": "."
-                }
+              "paths": {
+                "INCLUDE": "."
+              },
+              "locations": {
+                "VC_VC_IncludePath": "."
+              }
             }
         }
     },

--- a/crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json
+++ b/crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json
+++ b/crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json
+++ b/crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json
+++ b/crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json
+++ b/crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x64_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json
+++ b/crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json
@@ -12,10 +12,10 @@
         }
     },
     "exports": {
-        "paths": {
-            "lib": "."
-        },
-        "environment": {
+      "paths": {
+        "lib": ".",
+      },
+        "locations": {
             "VC_LibraryPath_VC_x64_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json
+++ b/crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json
+++ b/crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_OneCore_spectre": "."
         }
     },

--- a/crts/microsoft/onecore/arm/arm-14.28.29915.json
+++ b/crts/microsoft/onecore/arm/arm-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/arm/arm-14.29.30037.json
+++ b/crts/microsoft/onecore/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/arm64/arm64-14.28.29915.json
+++ b/crts/microsoft/onecore/arm64/arm64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/arm64/arm64-14.29.30037.json
+++ b/crts/microsoft/onecore/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_ARM64_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/x64/x64-14.28.29915.json
+++ b/crts/microsoft/onecore/x64/x64-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x64_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/x64/x64-14.29.30037.json
+++ b/crts/microsoft/onecore/x64/x64-14.29.30037.json
@@ -1,16 +1,16 @@
 {
-    "info": {
-        "id": "crts/microsoft/onecore/x64",
-        "version": "14.29.30037",
-        "summary": "MSVC standard library libraries (OneCore / apisets)",
-        "options": [ "dependencyOnly" ]
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
+  "info": {
+    "id": "crts/microsoft/onecore/x64",
+    "version": "14.29.30037",
+    "summary": "MSVC standard library libraries (OneCore / apisets)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
+    }
+  },
   "exports": {
     "paths": {
       "LIB": "."
@@ -19,17 +19,17 @@
       "VC_LibraryPath_VC_x64_OneCore": "."
     }
   },
-    "requires": {
-        "crts/microsoft/headers": "14.29.30037"
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.CRT.x64.OneCore.Desktop.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3326b6c4eb13290c41f51a5478aedbca5471f2c2d0be123dce3932ed21bafb6a/Microsoft.VC.14.29.16.10.CRT.x64.OneCore.Desktop.base.vsix"
-            ],
-            "sha256": "3326b6c4eb13290c41f51a5478aedbca5471f2c2d0be123dce3932ed21bafb6a",
-            "strip": 8
-        }
-    ]
+  "requires": {
+    "crts/microsoft/headers": "14.29.30037"
+  },
+  "install": [
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.CRT.x64.OneCore.Desktop.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3326b6c4eb13290c41f51a5478aedbca5471f2c2d0be123dce3932ed21bafb6a/Microsoft.VC.14.29.16.10.CRT.x64.OneCore.Desktop.base.vsix"
+      ],
+      "sha256": "3326b6c4eb13290c41f51a5478aedbca5471f2c2d0be123dce3932ed21bafb6a",
+      "strip": 8
+    }
+  ]
 }

--- a/crts/microsoft/onecore/x64/x64-14.29.30037.json
+++ b/crts/microsoft/onecore/x64/x64-14.29.30037.json
@@ -11,14 +11,14 @@
             "role": [ "publisher" ]
         }
     },
-    "exports": {
-        "paths": {
-            "lib": "."
-        },
-        "environment": {
-            "VC_LibraryPath_VC_x64_OneCore": "."
-        }
+  "exports": {
+    "paths": {
+      "LIB": "."
     },
+    "locations": {
+      "VC_LibraryPath_VC_x64_OneCore": "."
+    }
+  },
     "requires": {
         "crts/microsoft/headers": "14.29.30037"
     },

--- a/crts/microsoft/onecore/x86/x86-14.28.29915.json
+++ b/crts/microsoft/onecore/x86/x86-14.28.29915.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_VC_x86_OneCore": "."
         }
     },

--- a/crts/microsoft/onecore/x86/x86-14.29.30037.json
+++ b/crts/microsoft/onecore/x86/x86-14.29.30037.json
@@ -1,38 +1,45 @@
 {
-    "info": {
-        "id": "crts/microsoft/onecore/x86",
-        "version": "14.29.30037",
-        "summary": "MSVC standard library libraries (desktop / onecore)",
-        "options": [ "dependencyOnly" ]
+  "info": {
+    "id": "crts/microsoft/onecore/x86",
+    "version": "14.29.30037",
+    "summary": "MSVC standard library libraries (desktop / onecore)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
+    }
+  },
+  "requires": {
+    "crts/microsoft/headers": "14.29.30037"
+  },
+  "exports": {
+    "paths": {
+      "LIB": "."
     },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
+    "locations": {
+      "VC_LibraryPath_VC_x86_Onecore": "."
+    }
+  },
+  "demands": {
+    "windows": {
+      "exports": {
+        "paths": {
+          "LIB": ".",
+          "LIBPATH": "."
         }
-    },
-    "requires": {
-        "crts/microsoft/headers": "14.29.30037"
-    },
-    "demands": {
-        "windows": {
-            "exports": {
-                "paths": {
-                    "LIB": ".",
-                    "LIBPATH": ".",
-                    "VC_LibraryPath_VC_x86_Onecore": "."
-                }
-            }
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.CRT.x86.OneCore.Desktop.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/0f6de0c065116aa4e1353cb27d1aace4d28cd833d25f5f5789be5c89e4a9277c/Microsoft.VC.14.29.16.10.CRT.x86.OneCore.Desktop.base.vsix"
-            ],
-            "sha256": "0f6de0c065116aa4e1353cb27d1aace4d28cd833d25f5f5789be5c89e4a9277c",
-            "strip": 8
-        }
-    ]
+      }
+    }
+  },
+  "install": [
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.CRT.x86.OneCore.Desktop.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/0f6de0c065116aa4e1353cb27d1aace4d28cd833d25f5f5789be5c89e4a9277c/Microsoft.VC.14.29.16.10.CRT.x86.OneCore.Desktop.base.vsix"
+      ],
+      "sha256": "0f6de0c065116aa4e1353cb27d1aace4d28cd833d25f5f5789be5c89e4a9277c",
+      "strip": 8
+    }
+  ]
 }

--- a/index.yaml
+++ b/index.yaml
@@ -1,159 +1,159 @@
 # MANIFEST-INDEX
 items:
   [
-    compilers/arm/gcc/gcc-2020.10.0.json,    crts/microsoft/asan/asan-14.28.29915.json,    crts/microsoft/asan/x64/x64-14.29.30037.json,    crts/microsoft/asan/x64/x64-14.28.29915.json,    crts/microsoft/asan/asan-14.29.30037.json,    crts/microsoft/asan/x86/x86-14.28.29915.json,    crts/microsoft/asan/x86/x86-14.29.30037.json,    crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json,    crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.28.29915.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.29.30037.json,    crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json,    crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json,    crts/microsoft/desktop/arm/arm-14.29.30037.json,    crts/microsoft/desktop/arm/arm-14.28.29915.json,    crts/microsoft/desktop/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop/desktop-14.28.29915.json,    crts/microsoft/desktop/x64/x64-14.29.30037.json,    crts/microsoft/desktop/desktop-14.29.30037.json,    crts/microsoft/desktop/x64/x64-14.28.29915.json,    crts/microsoft/desktop/x86/x86-14.28.29915.json,    crts/microsoft/desktop/x86/x86-14.29.30037.json,    crts/microsoft/headers/headers-14.29.30037.json,    crts/microsoft/headers/headers-14.28.29912.json,    crts/microsoft/onecore/arm/arm-14.28.29915.json,    crts/microsoft/onecore/arm/arm-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore/x86/x86-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.29.30037.json,    crts/microsoft/onecore/onecore-14.29.30037.json,    crts/microsoft/onecore/x64/x64-14.28.29915.json,    crts/microsoft/onecore/onecore-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.29.30037.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.28.29915.json,    crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json,    crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json,    crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json,    crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json,    tools/compuphase/termite-3.4.0.json,    tools/arduino/arduino-cli-0.18.3.json,    tools/arduino/arduino-ide-1.18.15.json,    tools/kitware/cmake-3.20.1.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json,    tools/microsoft/openocd-0.11.0.json,    tools/ninja-build/ninja-1.10.2.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json,    tools/microsoft/openocd-0.11.0-ms1.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json,    tools/microsoft/msbuild/vc/UWP_17.0.0.json,    tools/microsoft/msbuild/vc/v143_17.0.0.json,    tools/microsoft/msbuild/vc/Desktop_v143_17.0.0.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json,    sdks/microsoft/atl/arm/arm-14.29.30037.json,    sdks/microsoft/atl/arm/arm-14.28.29914.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json,    sdks/microsoft/atl/atl-14.29.30037.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json,    sdks/microsoft/atl/atl-14.28.29914.json,    sdks/microsoft/atl/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl/x64/x64-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.28.29914.json,    sdks/microsoft/atl/x64/x64-14.28.29914.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json,    sdks/microsoft/atl-headers/atl-headers-14.29.30037.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json,    sdks/microsoft/atl-headers/atl-headers-14.28.29914.json,    sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl-spectre/atl-spectre-14.28.29914.json,    sdks/microsoft/atl-spectre/atl-spectre-14.29.30037.json,    sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json,    sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-headers/mfc-headers-14.28.29914.json,    sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/windows/windows-10.0.19041.json,    sdks/microsoft/windows/windows.arm-10.0.19041.json,    sdks/microsoft/windows/windows.arm64-10.0.19041.json,    sdks/microsoft/windows/windows.x64-10.0.19041.json,    sdks/microsoft/windows/windows.x86-10.0.19041.json,    microsoft/msvc/x64_arm/x64_arm-14.29.30037.json,    microsoft/msvc/msvc-14.28.29915.json,    microsoft/msvc/msvc-14.29.30037.json,    microsoft/msvc/x64_arm/x64_arm-14.28.29915.json,    microsoft/msvc/x64_x64/x64_x64-14.29.30037.json,    microsoft/msvc/x64_x64/x64_x64-14.28.29915.json,    microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json,    microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json,    microsoft/msvc/x64_x86/x64_x86-14.29.30037.json,    microsoft/msvc/x64_x86/x64_x86-14.28.29915.json,    microsoft/msvc/x86_arm/x86_arm-14.28.29915.json,    microsoft/msvc/x86_arm/x86_arm-14.29.30037.json,    microsoft/msvc/x86_x86/x86_x86-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.29.30037.json,    microsoft/msvc/x86_x64/x86_x64-14.28.29915.json,    microsoft/msvc/x86_x64/x86_x64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json,    microsoft/diasdk/diasdk-14.28.29915.json,    microsoft/diasdk/diasdk-14.29.30037.json
+    compilers/arm/gcc/gcc-2020.10.0.json,    crts/microsoft/asan/asan-14.29.30037.json,    crts/microsoft/asan/asan-14.28.29915.json,    crts/microsoft/asan/x64/x64-14.28.29915.json,    crts/microsoft/asan/x64/x64-14.29.30037.json,    crts/microsoft/asan/x86/x86-14.28.29915.json,    crts/microsoft/asan/x86/x86-14.29.30037.json,    crts/microsoft/desktop/arm/arm-14.28.29915.json,    crts/microsoft/desktop/arm/arm-14.29.30037.json,    crts/microsoft/desktop/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop/desktop-14.28.29915.json,    crts/microsoft/desktop/x64/x64-14.29.30037.json,    crts/microsoft/desktop/x64/x64-14.28.29915.json,    crts/microsoft/desktop/desktop-14.29.30037.json,    crts/microsoft/desktop/x86/x86-14.28.29915.json,    crts/microsoft/desktop/x86/x86-14.29.30037.json,    crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json,    crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.28.29915.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.29.30037.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json,    crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json,    crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json,    crts/microsoft/headers/headers-14.28.29912.json,    crts/microsoft/headers/headers-14.29.30037.json,    crts/microsoft/onecore/arm/arm-14.29.30037.json,    crts/microsoft/onecore/arm/arm-14.28.29915.json,    crts/microsoft/onecore/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore/onecore-14.29.30037.json,    crts/microsoft/onecore/onecore-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.28.29915.json,    crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json,    crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json,    crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.29.30037.json,    crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json,    tools/arduino/arduino-ide-1.18.15.json,    tools/arduino/arduino-cli-0.18.3.json,    tools/kitware/cmake-3.20.1.json,    tools/compuphase/termite-3.4.0.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json,    tools/microsoft/openocd-0.11.0.json,    tools/microsoft/msbuild/vc/v143_17.0.0.json,    tools/ninja-build/ninja-1.10.2.json,    tools/microsoft/openocd-0.11.0-ms1.json,    tools/microsoft/msbuild/vc/Desktop_v143_17.0.0.json,    tools/microsoft/msbuild/vc/UWP_17.0.0.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json,    sdks/microsoft/atl/arm/arm-14.29.30037.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json,    sdks/microsoft/atl/arm/arm-14.28.29914.json,    sdks/microsoft/atl/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl/atl-14.28.29914.json,    sdks/microsoft/atl/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl/atl-14.29.30037.json,    sdks/microsoft/atl/x64/x64-14.29.30037.json,    sdks/microsoft/atl/x64/x64-14.28.29914.json,    sdks/microsoft/atl/x86/x86-14.28.29914.json,    sdks/microsoft/atl/x86/x86-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl-spectre/atl-spectre-14.28.29914.json,    sdks/microsoft/atl-spectre/atl-spectre-14.29.30037.json,    sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json,    sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json,    sdks/microsoft/atl-headers/atl-headers-14.29.30037.json,    sdks/microsoft/atl-headers/atl-headers-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-headers/mfc-headers-14.28.29914.json,    sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json,    sdks/microsoft/windows/windows-10.0.19041.json,    sdks/microsoft/windows/windows.arm64-10.0.19041.json,    sdks/microsoft/windows/windows.x86-10.0.19041.json,    sdks/microsoft/windows/windows.arm-10.0.19041.json,    sdks/microsoft/windows/windows.x64-10.0.19041.json,    microsoft/diasdk/diasdk-14.28.29915.json,    microsoft/diasdk/diasdk-14.29.30037.json,    microsoft/msvc/msvc-14.28.29915.json,    microsoft/msvc/x64_arm/x64_arm-14.28.29915.json,    microsoft/msvc/msvc-14.29.30037.json,    microsoft/msvc/x64_arm/x64_arm-14.29.30037.json,    microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json,    microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json,    microsoft/msvc/x64_x86/x64_x86-14.28.29915.json,    microsoft/msvc/x64_x86/x64_x86-14.29.30037.json,    microsoft/msvc/x64_x64/x64_x64-14.28.29915.json,    microsoft/msvc/x64_x64/x64_x64-14.29.30037.json,    microsoft/msvc/x86_arm/x86_arm-14.29.30037.json,    microsoft/msvc/x86_arm/x86_arm-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.29.30037.json,    microsoft/msvc/x86_x64/x86_x64-14.28.29915.json,    microsoft/msvc/x86_x64/x86_x64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json
   ]
 indexes:
   IdentityKey/info.id:
     keys:
       compilers/arm/gcc: [ 0 ]
-      crts/microsoft/asan: [ 1, 4 ]
-      crts/microsoft/asan/x64: [ 2, 3 ]
+      crts/microsoft/asan: [ 1, 2 ]
+      crts/microsoft/asan/x64: [ 3, 4 ]
       crts/microsoft/asan/x86: [ 5, 6 ]
-      crts/microsoft/desktop: [ 21, 23 ]
-      crts/microsoft/desktop-spectre: [ 9, 14 ]
-      crts/microsoft/desktop-spectre/arm: [ 7, 8 ]
-      crts/microsoft/desktop-spectre/arm64: [ 10, 11 ]
-      crts/microsoft/desktop-spectre/x64: [ 12, 13 ]
-      crts/microsoft/desktop-spectre/x86: [ 15, 16 ]
-      crts/microsoft/desktop/arm: [ 17, 18 ]
-      crts/microsoft/desktop/arm64: [ 19, 20 ]
-      crts/microsoft/desktop/x64: [ 22, 24 ]
-      crts/microsoft/desktop/x86: [ 25, 26 ]
+      crts/microsoft/desktop: [ 11, 14 ]
+      crts/microsoft/desktop-spectre: [ 20, 21 ]
+      crts/microsoft/desktop-spectre/arm: [ 17, 18 ]
+      crts/microsoft/desktop-spectre/arm64: [ 19, 22 ]
+      crts/microsoft/desktop-spectre/x64: [ 23, 24 ]
+      crts/microsoft/desktop-spectre/x86: [ 25, 26 ]
+      crts/microsoft/desktop/arm: [ 7, 8 ]
+      crts/microsoft/desktop/arm64: [ 9, 10 ]
+      crts/microsoft/desktop/x64: [ 12, 13 ]
+      crts/microsoft/desktop/x86: [ 15, 16 ]
       crts/microsoft/headers: [ 27, 28 ]
-      crts/microsoft/onecore: [ 36, 38 ]
-      crts/microsoft/onecore-spectre: [ 43, 44 ]
+      crts/microsoft/onecore: [ 33, 34 ]
+      crts/microsoft/onecore-spectre: [ 43, 47 ]
       crts/microsoft/onecore-spectre/arm: [ 39, 40 ]
       crts/microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      crts/microsoft/onecore-spectre/x64: [ 47, 48 ]
-      crts/microsoft/onecore-spectre/x86: [ 45, 46 ]
+      crts/microsoft/onecore-spectre/x64: [ 44, 45 ]
+      crts/microsoft/onecore-spectre/x86: [ 46, 48 ]
       crts/microsoft/onecore/arm: [ 29, 30 ]
       crts/microsoft/onecore/arm64: [ 31, 32 ]
-      crts/microsoft/onecore/x64: [ 35, 37 ]
-      crts/microsoft/onecore/x86: [ 33, 34 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm: [ 53 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 54 ]
+      crts/microsoft/onecore/x64: [ 35, 36 ]
+      crts/microsoft/onecore/x86: [ 37, 38 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm: [ 54 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 53 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.v143: [ 56 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64: [ 55 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 61 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 62 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 59 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 59 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 57 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 66 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 67 ]
-      microsoft.visualstudio.vc.msbuild.v170.base: [ 68 ]
-      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 71 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64: [ 74 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 69 ]
+      microsoft.visualstudio.vc.msbuild.v170.base: [ 67 ]
+      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64: [ 68 ]
       microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 82 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86: [ 83 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 84 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 86 ]
-      microsoft/diasdk: [ 163, 164 ]
-      microsoft/msvc: [ 146, 147 ]
-      microsoft/msvc/x64_arm: [ 145, 148 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86: [ 71 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
+      microsoft/diasdk: [ 145, 146 ]
+      microsoft/msvc: [ 147, 149 ]
+      microsoft/msvc/x64_arm: [ 148, 150 ]
       microsoft/msvc/x64_arm64: [ 151, 152 ]
-      microsoft/msvc/x64_x64: [ 149, 150 ]
+      microsoft/msvc/x64_x64: [ 155, 156 ]
       microsoft/msvc/x64_x86: [ 153, 154 ]
-      microsoft/msvc/x86_arm: [ 155, 156 ]
-      microsoft/msvc/x86_arm64: [ 161, 162 ]
-      microsoft/msvc/x86_x64: [ 159, 160 ]
-      microsoft/msvc/x86_x86: [ 157, 158 ]
-      sdks/microsoft/atl: [ 73, 75 ]
-      sdks/microsoft/atl-headers: [ 85, 87 ]
-      sdks/microsoft/atl-spectre: [ 92, 93 ]
-      sdks/microsoft/atl-spectre/arm: [ 88, 89 ]
-      sdks/microsoft/atl-spectre/arm64: [ 90, 91 ]
-      sdks/microsoft/atl-spectre/x64: [ 94, 95 ]
-      sdks/microsoft/atl-spectre/x86: [ 96, 97 ]
-      sdks/microsoft/atl/arm: [ 69, 70 ]
-      sdks/microsoft/atl/arm64: [ 76, 77 ]
-      sdks/microsoft/atl/x64: [ 78, 81 ]
-      sdks/microsoft/atl/x86: [ 79, 80 ]
-      sdks/microsoft/mfc-headers: [ 118, 119 ]
-      sdks/microsoft/mfc-spectre/mbcs: [ 126, 127 ]
-      sdks/microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
+      microsoft/msvc/x86_arm: [ 157, 158 ]
+      microsoft/msvc/x86_arm64: [ 163, 164 ]
+      microsoft/msvc/x86_x64: [ 161, 162 ]
+      microsoft/msvc/x86_x86: [ 159, 160 ]
+      sdks/microsoft/atl: [ 79, 81 ]
+      sdks/microsoft/atl-headers: [ 96, 97 ]
+      sdks/microsoft/atl-spectre: [ 90, 91 ]
+      sdks/microsoft/atl-spectre/arm: [ 86, 87 ]
+      sdks/microsoft/atl-spectre/arm64: [ 88, 89 ]
+      sdks/microsoft/atl-spectre/x64: [ 92, 93 ]
+      sdks/microsoft/atl-spectre/x86: [ 94, 95 ]
+      sdks/microsoft/atl/arm: [ 74, 77 ]
+      sdks/microsoft/atl/arm64: [ 78, 80 ]
+      sdks/microsoft/atl/x64: [ 82, 83 ]
+      sdks/microsoft/atl/x86: [ 84, 85 ]
+      sdks/microsoft/mfc-headers: [ 138, 139 ]
+      sdks/microsoft/mfc-spectre/mbcs: [ 124, 125 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm: [ 118, 119 ]
       sdks/microsoft/mfc-spectre/mbcs/arm64: [ 120, 121 ]
-      sdks/microsoft/mfc-spectre/mbcs/x64: [ 124, 125 ]
-      sdks/microsoft/mfc-spectre/mbcs/x86: [ 128, 129 ]
-      sdks/microsoft/mfc-spectre/unicode: [ 132, 133 ]
-      sdks/microsoft/mfc-spectre/unicode/arm: [ 130, 131 ]
-      sdks/microsoft/mfc-spectre/unicode/arm64: [ 134, 135 ]
-      sdks/microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
-      sdks/microsoft/mfc-spectre/unicode/x86: [ 138, 139 ]
-      sdks/microsoft/mfc/mbcs: [ 102, 105 ]
+      sdks/microsoft/mfc-spectre/mbcs/x64: [ 122, 123 ]
+      sdks/microsoft/mfc-spectre/mbcs/x86: [ 126, 127 ]
+      sdks/microsoft/mfc-spectre/unicode: [ 130, 132 ]
+      sdks/microsoft/mfc-spectre/unicode/arm: [ 128, 129 ]
+      sdks/microsoft/mfc-spectre/unicode/arm64: [ 131, 133 ]
+      sdks/microsoft/mfc-spectre/unicode/x64: [ 134, 135 ]
+      sdks/microsoft/mfc-spectre/unicode/x86: [ 136, 137 ]
+      sdks/microsoft/mfc/mbcs: [ 103, 104 ]
       sdks/microsoft/mfc/mbcs/arm: [ 98, 99 ]
       sdks/microsoft/mfc/mbcs/arm64: [ 100, 101 ]
-      sdks/microsoft/mfc/mbcs/x64: [ 103, 104 ]
+      sdks/microsoft/mfc/mbcs/x64: [ 102, 105 ]
       sdks/microsoft/mfc/mbcs/x86: [ 106, 107 ]
-      sdks/microsoft/mfc/unicode: [ 112, 114 ]
+      sdks/microsoft/mfc/unicode: [ 113, 115 ]
       sdks/microsoft/mfc/unicode/arm: [ 108, 109 ]
       sdks/microsoft/mfc/unicode/arm64: [ 110, 111 ]
-      sdks/microsoft/mfc/unicode/x64: [ 113, 115 ]
+      sdks/microsoft/mfc/unicode/x64: [ 112, 114 ]
       sdks/microsoft/mfc/unicode/x86: [ 116, 117 ]
-      sdks/microsoft/windows/windows: [ 140 ]
-      sdks/microsoft/windows/windows.arm: [ 141 ]
-      sdks/microsoft/windows/windows.arm64: [ 142 ]
-      sdks/microsoft/windows/windows.x64: [ 143 ]
-      sdks/microsoft/windows/windows.x86: [ 144 ]
+      sdks/microsoft/windows: [ 140 ]
+      sdks/microsoft/windows/windows.arm: [ 143 ]
+      sdks/microsoft/windows/windows.arm64: [ 141 ]
+      sdks/microsoft/windows/windows.x64: [ 144 ]
+      sdks/microsoft/windows/windows.x86: [ 142 ]
       tools/arduino/arduino-cli: [ 50 ]
-      tools/arduino/arduino-ide: [ 51 ]
-      tools/compuphase/termite: [ 49 ]
-      tools/kitware/cmake: [ 52 ]
-      tools/microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      tools/microsoft/msbuild/vc/uwp: [ 63 ]
-      tools/microsoft/msbuild/vc/v143: [ 64 ]
-      tools/microsoft/openocd: [ 57, 60 ]
-      tools/ninja-build/ninja: [ 58 ]
+      tools/arduino/arduino-ide: [ 49 ]
+      tools/compuphase/termite: [ 52 ]
+      tools/kitware/cmake: [ 51 ]
+      tools/microsoft/msbuild/vc/Desktop/v143: [ 64 ]
+      tools/microsoft/msbuild/vc/uwp: [ 65 ]
+      tools/microsoft/msbuild/vc/v143: [ 61 ]
+      tools/microsoft/openocd: [ 60, 63 ]
+      tools/ninja-build/ninja: [ 62 ]
     words:
-      Desktop: [ 65 ]
-      Desktop/v143: [ 65 ]
-      arduino: [ 50, 51 ]
+      Desktop: [ 64 ]
+      Desktop/v143: [ 64 ]
+      arduino: [ 49, 50 ]
       arduino-cli: [ 50 ]
-      arduino-ide: [ 51 ]
-      arduino/arduino: [ 50, 51 ]
+      arduino-ide: [ 49 ]
+      arduino/arduino: [ 49, 50 ]
       arduino/arduino-cli: [ 50 ]
-      arduino/arduino-ide: [ 51 ]
+      arduino/arduino-ide: [ 49 ]
       arm:
-        [0,7,8,17,18,29,30,39,40,53,54,56,69,70,88,89,98,99,108,109,122,123,130,131,          141
+        [0,7,8,17,18,29,30,39,40,53,54,56,74,77,86,87,98,99,108,109,118,119,128,129,          143
         ]
-      arm.uwp: [ 54 ]
+      arm.uwp: [ 53 ]
       arm.v143: [ 56 ]
       arm/gcc: [ 0 ]
       arm64:
-        [10,11,19,20,31,32,41,42,55,61,62,76,77,90,91,100,101,110,111,120,121,134,135,          142
+        [9,10,19,22,31,32,41,42,55,58,59,78,80,88,89,100,101,110,111,120,121,131,133,          141
         ]
-      arm64.uwp: [ 61 ]
-      arm64.v143: [ 62 ]
-      arm64ec: [ 59, 66, 67 ]
+      arm64.uwp: [ 59 ]
+      arm64.v143: [ 58 ]
+      arm64ec: [ 57, 66, 69 ]
       arm64ec.uwp: [ 66 ]
-      arm64ec.v143: [ 67 ]
+      arm64ec.v143: [ 69 ]
       asan: [ 1, 2, 3, 4, 5, 6 ]
-      asan/x64: [ 2, 3 ]
+      asan/x64: [ 3, 4 ]
       asan/x86: [ 5, 6 ]
       atl:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
-      atl-headers: [ 85, 87 ]
-      atl-spectre: [ 88, 89, 90, 91, 92, 93, 94, 95, 96, 97 ]
-      atl-spectre/arm: [ 88, 89 ]
-      atl-spectre/arm64: [ 90, 91 ]
-      atl-spectre/x64: [ 94, 95 ]
-      atl-spectre/x86: [ 96, 97 ]
-      atl/arm: [ 69, 70 ]
-      atl/arm64: [ 76, 77 ]
-      atl/x64: [ 78, 81 ]
-      atl/x86: [ 79, 80 ]
-      base: [ 68, 71 ]
-      base.uwp: [ 71 ]
-      build: [ 58 ]
-      build/ninja: [ 58 ]
+      atl-headers: [ 96, 97 ]
+      atl-spectre: [ 86, 87, 88, 89, 90, 91, 92, 93, 94, 95 ]
+      atl-spectre/arm: [ 86, 87 ]
+      atl-spectre/arm64: [ 88, 89 ]
+      atl-spectre/x64: [ 92, 93 ]
+      atl-spectre/x86: [ 94, 95 ]
+      atl/arm: [ 74, 77 ]
+      atl/arm64: [ 78, 80 ]
+      atl/x64: [ 82, 83 ]
+      atl/x86: [ 84, 85 ]
+      base: [ 67, 70 ]
+      base.uwp: [ 70 ]
+      build: [ 62 ]
+      build/ninja: [ 62 ]
       cli: [ 50 ]
-      cmake: [ 52 ]
+      cmake: [ 51 ]
       compilers: [ 0 ]
       compilers/arm: [ 0 ]
       compilers/arm/gcc: [ 0 ]
-      compuphase: [ 49 ]
-      compuphase/termite: [ 49 ]
+      compuphase: [ 52 ]
+      compuphase/termite: [ 52 ]
       crts:
         [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
@@ -161,20 +161,20 @@ indexes:
         [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       crts/microsoft/asan: [ 1, 2, 3, 4, 5, 6 ]
-      crts/microsoft/asan/x64: [ 2, 3 ]
+      crts/microsoft/asan/x64: [ 3, 4 ]
       crts/microsoft/asan/x86: [ 5, 6 ]
       crts/microsoft/desktop:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
-      crts/microsoft/desktop-spectre: [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
-      crts/microsoft/desktop-spectre/arm: [ 7, 8 ]
-      crts/microsoft/desktop-spectre/arm64: [ 10, 11 ]
-      crts/microsoft/desktop-spectre/x64: [ 12, 13 ]
-      crts/microsoft/desktop-spectre/x86: [ 15, 16 ]
-      crts/microsoft/desktop/arm: [ 17, 18 ]
-      crts/microsoft/desktop/arm64: [ 19, 20 ]
-      crts/microsoft/desktop/x64: [ 22, 24 ]
-      crts/microsoft/desktop/x86: [ 25, 26 ]
+      crts/microsoft/desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+      crts/microsoft/desktop-spectre/arm: [ 17, 18 ]
+      crts/microsoft/desktop-spectre/arm64: [ 19, 22 ]
+      crts/microsoft/desktop-spectre/x64: [ 23, 24 ]
+      crts/microsoft/desktop-spectre/x86: [ 25, 26 ]
+      crts/microsoft/desktop/arm: [ 7, 8 ]
+      crts/microsoft/desktop/arm64: [ 9, 10 ]
+      crts/microsoft/desktop/x64: [ 12, 13 ]
+      crts/microsoft/desktop/x86: [ 15, 16 ]
       crts/microsoft/headers: [ 27, 28 ]
       crts/microsoft/onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
@@ -182,552 +182,552 @@ indexes:
       crts/microsoft/onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
       crts/microsoft/onecore-spectre/arm: [ 39, 40 ]
       crts/microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      crts/microsoft/onecore-spectre/x64: [ 47, 48 ]
-      crts/microsoft/onecore-spectre/x86: [ 45, 46 ]
+      crts/microsoft/onecore-spectre/x64: [ 44, 45 ]
+      crts/microsoft/onecore-spectre/x86: [ 46, 48 ]
       crts/microsoft/onecore/arm: [ 29, 30 ]
       crts/microsoft/onecore/arm64: [ 31, 32 ]
-      crts/microsoft/onecore/x64: [ 35, 37 ]
-      crts/microsoft/onecore/x86: [ 33, 34 ]
+      crts/microsoft/onecore/x64: [ 35, 36 ]
+      crts/microsoft/onecore/x86: [ 37, 38 ]
       desktop:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
-      desktop-spectre: [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
-      desktop-spectre/arm: [ 7, 8 ]
-      desktop-spectre/arm64: [ 10, 11 ]
-      desktop-spectre/x64: [ 12, 13 ]
-      desktop-spectre/x86: [ 15, 16 ]
-      desktop/arm: [ 17, 18 ]
-      desktop/arm64: [ 19, 20 ]
-      desktop/x64: [ 22, 24 ]
-      desktop/x86: [ 25, 26 ]
-      diasdk: [ 163, 164 ]
+      desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+      desktop-spectre/arm: [ 17, 18 ]
+      desktop-spectre/arm64: [ 19, 22 ]
+      desktop-spectre/x64: [ 23, 24 ]
+      desktop-spectre/x86: [ 25, 26 ]
+      desktop/arm: [ 7, 8 ]
+      desktop/arm64: [ 9, 10 ]
+      desktop/x64: [ 12, 13 ]
+      desktop/x86: [ 15, 16 ]
+      diasdk: [ 145, 146 ]
       gcc: [ 0 ]
-      headers: [ 27, 28, 85, 87, 118, 119 ]
-      ide: [ 51 ]
-      kitware: [ 52 ]
-      kitware/cmake: [ 52 ]
+      headers: [ 27, 28, 96, 97, 138, 139 ]
+      ide: [ 49 ]
+      kitware: [ 51 ]
+      kitware/cmake: [ 51 ]
       mbcs:
-        [98,99,100,101,102,103,104,105,106,107,120,121,122,123,124,125,126,127,128,          129
+        [98,99,100,101,102,103,104,105,106,107,118,119,120,121,122,123,124,125,126,          127
         ]
-      mbcs/arm: [ 98, 99, 122, 123 ]
+      mbcs/arm: [ 98, 99, 118, 119 ]
       mbcs/arm64: [ 100, 101, 120, 121 ]
-      mbcs/x64: [ 103, 104, 124, 125 ]
-      mbcs/x86: [ 106, 107, 128, 129 ]
+      mbcs/x64: [ 102, 105, 122, 123 ]
+      mbcs/x86: [ 106, 107, 126, 127 ]
       mfc:
         [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
         ]
-      mfc-headers: [ 118, 119 ]
+      mfc-headers: [ 138, 139 ]
       mfc-spectre:
-        [120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
       mfc-spectre/mbcs:
-        [120,121,122,123,124,125,126,127,128,          129
+        [118,119,120,121,122,123,124,125,126,          127
         ]
-      mfc-spectre/mbcs/arm: [ 122, 123 ]
+      mfc-spectre/mbcs/arm: [ 118, 119 ]
       mfc-spectre/mbcs/arm64: [ 120, 121 ]
-      mfc-spectre/mbcs/x64: [ 124, 125 ]
-      mfc-spectre/mbcs/x86: [ 128, 129 ]
+      mfc-spectre/mbcs/x64: [ 122, 123 ]
+      mfc-spectre/mbcs/x86: [ 126, 127 ]
       mfc-spectre/unicode:
-        [130,131,132,133,134,135,136,137,138,          139
+        [128,129,130,131,132,133,134,135,136,          137
         ]
-      mfc-spectre/unicode/arm: [ 130, 131 ]
-      mfc-spectre/unicode/arm64: [ 134, 135 ]
-      mfc-spectre/unicode/x64: [ 136, 137 ]
-      mfc-spectre/unicode/x86: [ 138, 139 ]
+      mfc-spectre/unicode/arm: [ 128, 129 ]
+      mfc-spectre/unicode/arm64: [ 131, 133 ]
+      mfc-spectre/unicode/x64: [ 134, 135 ]
+      mfc-spectre/unicode/x86: [ 136, 137 ]
       mfc/mbcs: [ 98, 99, 100, 101, 102, 103, 104, 105, 106, 107 ]
       mfc/mbcs/arm: [ 98, 99 ]
       mfc/mbcs/arm64: [ 100, 101 ]
-      mfc/mbcs/x64: [ 103, 104 ]
+      mfc/mbcs/x64: [ 102, 105 ]
       mfc/mbcs/x86: [ 106, 107 ]
       mfc/unicode:
         [108,109,110,111,112,113,114,115,116,          117
         ]
       mfc/unicode/arm: [ 108, 109 ]
       mfc/unicode/arm64: [ 110, 111 ]
-      mfc/unicode/x64: [ 113, 115 ]
+      mfc/unicode/x64: [ 112, 114 ]
       mfc/unicode/x86: [ 116, 117 ]
       microsoft:
-        [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,53,54,55,56,57,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
+        [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,53,54,55,56,57,58,59,60,61,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
       microsoft.visualstudio:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       microsoft.visualstudio.vc:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       microsoft.visualstudio.vc.msbuild:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       microsoft.visualstudio.vc.msbuild.v170:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       microsoft.visualstudio.vc.msbuild.v170.arm: [ 53, 54, 56 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 54 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 53 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.v143: [ 56 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64: [ 55, 61, 62 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 61 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 62 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 59, 66, 67 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64: [ 55, 58, 59 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 59 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 57, 66, 69 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 66 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 67 ]
-      microsoft.visualstudio.vc.msbuild.v170.base: [ 68, 71 ]
-      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 71 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64: [ 72, 74, 82 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 69 ]
+      microsoft.visualstudio.vc.msbuild.v170.base: [ 67, 70 ]
+      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64: [ 68, 72, 73 ]
       microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 82 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86: [ 83, 84, 86 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 84 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 86 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86: [ 71, 75, 76 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
       microsoft/asan: [ 1, 2, 3, 4, 5, 6 ]
-      microsoft/asan/x64: [ 2, 3 ]
+      microsoft/asan/x64: [ 3, 4 ]
       microsoft/asan/x86: [ 5, 6 ]
       microsoft/atl:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
-      microsoft/atl-headers: [ 85, 87 ]
-      microsoft/atl-spectre: [ 88, 89, 90, 91, 92, 93, 94, 95, 96, 97 ]
-      microsoft/atl-spectre/arm: [ 88, 89 ]
-      microsoft/atl-spectre/arm64: [ 90, 91 ]
-      microsoft/atl-spectre/x64: [ 94, 95 ]
-      microsoft/atl-spectre/x86: [ 96, 97 ]
-      microsoft/atl/arm: [ 69, 70 ]
-      microsoft/atl/arm64: [ 76, 77 ]
-      microsoft/atl/x64: [ 78, 81 ]
-      microsoft/atl/x86: [ 79, 80 ]
+      microsoft/atl-headers: [ 96, 97 ]
+      microsoft/atl-spectre: [ 86, 87, 88, 89, 90, 91, 92, 93, 94, 95 ]
+      microsoft/atl-spectre/arm: [ 86, 87 ]
+      microsoft/atl-spectre/arm64: [ 88, 89 ]
+      microsoft/atl-spectre/x64: [ 92, 93 ]
+      microsoft/atl-spectre/x86: [ 94, 95 ]
+      microsoft/atl/arm: [ 74, 77 ]
+      microsoft/atl/arm64: [ 78, 80 ]
+      microsoft/atl/x64: [ 82, 83 ]
+      microsoft/atl/x86: [ 84, 85 ]
       microsoft/desktop:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
-      microsoft/desktop-spectre: [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
-      microsoft/desktop-spectre/arm: [ 7, 8 ]
-      microsoft/desktop-spectre/arm64: [ 10, 11 ]
-      microsoft/desktop-spectre/x64: [ 12, 13 ]
-      microsoft/desktop-spectre/x86: [ 15, 16 ]
-      microsoft/desktop/arm: [ 17, 18 ]
-      microsoft/desktop/arm64: [ 19, 20 ]
-      microsoft/desktop/x64: [ 22, 24 ]
-      microsoft/desktop/x86: [ 25, 26 ]
-      microsoft/diasdk: [ 163, 164 ]
+      microsoft/desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+      microsoft/desktop-spectre/arm: [ 17, 18 ]
+      microsoft/desktop-spectre/arm64: [ 19, 22 ]
+      microsoft/desktop-spectre/x64: [ 23, 24 ]
+      microsoft/desktop-spectre/x86: [ 25, 26 ]
+      microsoft/desktop/arm: [ 7, 8 ]
+      microsoft/desktop/arm64: [ 9, 10 ]
+      microsoft/desktop/x64: [ 12, 13 ]
+      microsoft/desktop/x86: [ 15, 16 ]
+      microsoft/diasdk: [ 145, 146 ]
       microsoft/headers: [ 27, 28 ]
       microsoft/mfc:
         [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
         ]
-      microsoft/mfc-headers: [ 118, 119 ]
+      microsoft/mfc-headers: [ 138, 139 ]
       microsoft/mfc-spectre:
-        [120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
       microsoft/mfc-spectre/mbcs:
-        [120,121,122,123,124,125,126,127,128,          129
+        [118,119,120,121,122,123,124,125,126,          127
         ]
-      microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
+      microsoft/mfc-spectre/mbcs/arm: [ 118, 119 ]
       microsoft/mfc-spectre/mbcs/arm64: [ 120, 121 ]
-      microsoft/mfc-spectre/mbcs/x64: [ 124, 125 ]
-      microsoft/mfc-spectre/mbcs/x86: [ 128, 129 ]
+      microsoft/mfc-spectre/mbcs/x64: [ 122, 123 ]
+      microsoft/mfc-spectre/mbcs/x86: [ 126, 127 ]
       microsoft/mfc-spectre/unicode:
-        [130,131,132,133,134,135,136,137,138,          139
+        [128,129,130,131,132,133,134,135,136,          137
         ]
-      microsoft/mfc-spectre/unicode/arm: [ 130, 131 ]
-      microsoft/mfc-spectre/unicode/arm64: [ 134, 135 ]
-      microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
-      microsoft/mfc-spectre/unicode/x86: [ 138, 139 ]
+      microsoft/mfc-spectre/unicode/arm: [ 128, 129 ]
+      microsoft/mfc-spectre/unicode/arm64: [ 131, 133 ]
+      microsoft/mfc-spectre/unicode/x64: [ 134, 135 ]
+      microsoft/mfc-spectre/unicode/x86: [ 136, 137 ]
       microsoft/mfc/mbcs: [ 98, 99, 100, 101, 102, 103, 104, 105, 106, 107 ]
       microsoft/mfc/mbcs/arm: [ 98, 99 ]
       microsoft/mfc/mbcs/arm64: [ 100, 101 ]
-      microsoft/mfc/mbcs/x64: [ 103, 104 ]
+      microsoft/mfc/mbcs/x64: [ 102, 105 ]
       microsoft/mfc/mbcs/x86: [ 106, 107 ]
       microsoft/mfc/unicode:
         [108,109,110,111,112,113,114,115,116,          117
         ]
       microsoft/mfc/unicode/arm: [ 108, 109 ]
       microsoft/mfc/unicode/arm64: [ 110, 111 ]
-      microsoft/mfc/unicode/x64: [ 113, 115 ]
+      microsoft/mfc/unicode/x64: [ 112, 114 ]
       microsoft/mfc/unicode/x86: [ 116, 117 ]
-      microsoft/msbuild: [ 63, 64, 65 ]
-      microsoft/msbuild/vc: [ 63, 64, 65 ]
-      microsoft/msbuild/vc/Desktop: [ 65 ]
-      microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      microsoft/msbuild/vc/uwp: [ 63 ]
-      microsoft/msbuild/vc/v143: [ 64 ]
+      microsoft/msbuild: [ 61, 64, 65 ]
+      microsoft/msbuild/vc: [ 61, 64, 65 ]
+      microsoft/msbuild/vc/Desktop: [ 64 ]
+      microsoft/msbuild/vc/Desktop/v143: [ 64 ]
+      microsoft/msbuild/vc/uwp: [ 65 ]
+      microsoft/msbuild/vc/v143: [ 61 ]
       microsoft/msvc:
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
-      microsoft/msvc/x64_arm: [ 145, 148 ]
+      microsoft/msvc/x64_arm: [ 148, 150 ]
       microsoft/msvc/x64_arm64: [ 151, 152 ]
-      microsoft/msvc/x64_x64: [ 149, 150 ]
+      microsoft/msvc/x64_x64: [ 155, 156 ]
       microsoft/msvc/x64_x86: [ 153, 154 ]
-      microsoft/msvc/x86_arm: [ 155, 156 ]
-      microsoft/msvc/x86_arm64: [ 161, 162 ]
-      microsoft/msvc/x86_x64: [ 159, 160 ]
-      microsoft/msvc/x86_x86: [ 157, 158 ]
+      microsoft/msvc/x86_arm: [ 157, 158 ]
+      microsoft/msvc/x86_arm64: [ 163, 164 ]
+      microsoft/msvc/x86_x64: [ 161, 162 ]
+      microsoft/msvc/x86_x86: [ 159, 160 ]
       microsoft/onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       microsoft/onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
       microsoft/onecore-spectre/arm: [ 39, 40 ]
       microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      microsoft/onecore-spectre/x64: [ 47, 48 ]
-      microsoft/onecore-spectre/x86: [ 45, 46 ]
+      microsoft/onecore-spectre/x64: [ 44, 45 ]
+      microsoft/onecore-spectre/x86: [ 46, 48 ]
       microsoft/onecore/arm: [ 29, 30 ]
       microsoft/onecore/arm64: [ 31, 32 ]
-      microsoft/onecore/x64: [ 35, 37 ]
-      microsoft/onecore/x86: [ 33, 34 ]
-      microsoft/openocd: [ 57, 60 ]
+      microsoft/onecore/x64: [ 35, 36 ]
+      microsoft/onecore/x86: [ 37, 38 ]
+      microsoft/openocd: [ 60, 63 ]
       microsoft/windows: [ 140, 141, 142, 143, 144 ]
-      microsoft/windows/windows: [ 140, 141, 142, 143, 144 ]
-      microsoft/windows/windows.arm: [ 141 ]
-      microsoft/windows/windows.arm64: [ 142 ]
-      microsoft/windows/windows.x64: [ 143 ]
-      microsoft/windows/windows.x86: [ 144 ]
+      microsoft/windows/windows: [ 141, 142, 143, 144 ]
+      microsoft/windows/windows.arm: [ 143 ]
+      microsoft/windows/windows.arm64: [ 141 ]
+      microsoft/windows/windows.x64: [ 144 ]
+      microsoft/windows/windows.x86: [ 142 ]
       msbuild:
-        [53,54,55,56,59,61,62,63,64,65,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,61,64,65,66,67,68,69,70,71,72,73,75,          76
         ]
       msbuild.v170:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       msbuild.v170.arm: [ 53, 54, 56 ]
-      msbuild.v170.arm.uwp: [ 54 ]
+      msbuild.v170.arm.uwp: [ 53 ]
       msbuild.v170.arm.v143: [ 56 ]
-      msbuild.v170.arm64: [ 55, 61, 62 ]
-      msbuild.v170.arm64.uwp: [ 61 ]
-      msbuild.v170.arm64.v143: [ 62 ]
-      msbuild.v170.arm64ec: [ 59, 66, 67 ]
+      msbuild.v170.arm64: [ 55, 58, 59 ]
+      msbuild.v170.arm64.uwp: [ 59 ]
+      msbuild.v170.arm64.v143: [ 58 ]
+      msbuild.v170.arm64ec: [ 57, 66, 69 ]
       msbuild.v170.arm64ec.uwp: [ 66 ]
-      msbuild.v170.arm64ec.v143: [ 67 ]
-      msbuild.v170.base: [ 68, 71 ]
-      msbuild.v170.base.uwp: [ 71 ]
-      msbuild.v170.x64: [ 72, 74, 82 ]
+      msbuild.v170.arm64ec.v143: [ 69 ]
+      msbuild.v170.base: [ 67, 70 ]
+      msbuild.v170.base.uwp: [ 70 ]
+      msbuild.v170.x64: [ 68, 72, 73 ]
       msbuild.v170.x64.uwp: [ 72 ]
-      msbuild.v170.x64.v143: [ 82 ]
-      msbuild.v170.x86: [ 83, 84, 86 ]
-      msbuild.v170.x86.uwp: [ 84 ]
-      msbuild.v170.x86.v143: [ 86 ]
-      msbuild/vc: [ 63, 64, 65 ]
-      msbuild/vc/Desktop: [ 65 ]
-      msbuild/vc/Desktop/v143: [ 65 ]
-      msbuild/vc/uwp: [ 63 ]
-      msbuild/vc/v143: [ 64 ]
+      msbuild.v170.x64.v143: [ 73 ]
+      msbuild.v170.x86: [ 71, 75, 76 ]
+      msbuild.v170.x86.uwp: [ 75 ]
+      msbuild.v170.x86.v143: [ 76 ]
+      msbuild/vc: [ 61, 64, 65 ]
+      msbuild/vc/Desktop: [ 64 ]
+      msbuild/vc/Desktop/v143: [ 64 ]
+      msbuild/vc/uwp: [ 65 ]
+      msbuild/vc/v143: [ 61 ]
       msvc:
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
-      msvc/x64_arm: [ 145, 148 ]
+      msvc/x64_arm: [ 148, 150 ]
       msvc/x64_arm64: [ 151, 152 ]
-      msvc/x64_x64: [ 149, 150 ]
+      msvc/x64_x64: [ 155, 156 ]
       msvc/x64_x86: [ 153, 154 ]
-      msvc/x86_arm: [ 155, 156 ]
-      msvc/x86_arm64: [ 161, 162 ]
-      msvc/x86_x64: [ 159, 160 ]
-      msvc/x86_x86: [ 157, 158 ]
-      ninja: [ 58 ]
-      ninja-build: [ 58 ]
-      ninja-build/ninja: [ 58 ]
+      msvc/x86_arm: [ 157, 158 ]
+      msvc/x86_arm64: [ 163, 164 ]
+      msvc/x86_x64: [ 161, 162 ]
+      msvc/x86_x86: [ 159, 160 ]
+      ninja: [ 62 ]
+      ninja-build: [ 62 ]
+      ninja-build/ninja: [ 62 ]
       onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
       onecore-spectre/arm: [ 39, 40 ]
       onecore-spectre/arm64: [ 41, 42 ]
-      onecore-spectre/x64: [ 47, 48 ]
-      onecore-spectre/x86: [ 45, 46 ]
+      onecore-spectre/x64: [ 44, 45 ]
+      onecore-spectre/x86: [ 46, 48 ]
       onecore/arm: [ 29, 30 ]
       onecore/arm64: [ 31, 32 ]
-      onecore/x64: [ 35, 37 ]
-      onecore/x86: [ 33, 34 ]
-      openocd: [ 57, 60 ]
+      onecore/x64: [ 35, 36 ]
+      onecore/x86: [ 37, 38 ]
+      openocd: [ 60, 63 ]
       sdks:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,          144
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,          144
         ]
       sdks/microsoft:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,          144
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,          144
         ]
       sdks/microsoft/atl:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
-      sdks/microsoft/atl-headers: [ 85, 87 ]
-      sdks/microsoft/atl-spectre: [ 88, 89, 90, 91, 92, 93, 94, 95, 96, 97 ]
-      sdks/microsoft/atl-spectre/arm: [ 88, 89 ]
-      sdks/microsoft/atl-spectre/arm64: [ 90, 91 ]
-      sdks/microsoft/atl-spectre/x64: [ 94, 95 ]
-      sdks/microsoft/atl-spectre/x86: [ 96, 97 ]
-      sdks/microsoft/atl/arm: [ 69, 70 ]
-      sdks/microsoft/atl/arm64: [ 76, 77 ]
-      sdks/microsoft/atl/x64: [ 78, 81 ]
-      sdks/microsoft/atl/x86: [ 79, 80 ]
+      sdks/microsoft/atl-headers: [ 96, 97 ]
+      sdks/microsoft/atl-spectre: [ 86, 87, 88, 89, 90, 91, 92, 93, 94, 95 ]
+      sdks/microsoft/atl-spectre/arm: [ 86, 87 ]
+      sdks/microsoft/atl-spectre/arm64: [ 88, 89 ]
+      sdks/microsoft/atl-spectre/x64: [ 92, 93 ]
+      sdks/microsoft/atl-spectre/x86: [ 94, 95 ]
+      sdks/microsoft/atl/arm: [ 74, 77 ]
+      sdks/microsoft/atl/arm64: [ 78, 80 ]
+      sdks/microsoft/atl/x64: [ 82, 83 ]
+      sdks/microsoft/atl/x86: [ 84, 85 ]
       sdks/microsoft/mfc:
         [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
         ]
-      sdks/microsoft/mfc-headers: [ 118, 119 ]
+      sdks/microsoft/mfc-headers: [ 138, 139 ]
       sdks/microsoft/mfc-spectre:
-        [120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
       sdks/microsoft/mfc-spectre/mbcs:
-        [120,121,122,123,124,125,126,127,128,          129
+        [118,119,120,121,122,123,124,125,126,          127
         ]
-      sdks/microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm: [ 118, 119 ]
       sdks/microsoft/mfc-spectre/mbcs/arm64: [ 120, 121 ]
-      sdks/microsoft/mfc-spectre/mbcs/x64: [ 124, 125 ]
-      sdks/microsoft/mfc-spectre/mbcs/x86: [ 128, 129 ]
+      sdks/microsoft/mfc-spectre/mbcs/x64: [ 122, 123 ]
+      sdks/microsoft/mfc-spectre/mbcs/x86: [ 126, 127 ]
       sdks/microsoft/mfc-spectre/unicode:
-        [130,131,132,133,134,135,136,137,138,          139
+        [128,129,130,131,132,133,134,135,136,          137
         ]
-      sdks/microsoft/mfc-spectre/unicode/arm: [ 130, 131 ]
-      sdks/microsoft/mfc-spectre/unicode/arm64: [ 134, 135 ]
-      sdks/microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
-      sdks/microsoft/mfc-spectre/unicode/x86: [ 138, 139 ]
+      sdks/microsoft/mfc-spectre/unicode/arm: [ 128, 129 ]
+      sdks/microsoft/mfc-spectre/unicode/arm64: [ 131, 133 ]
+      sdks/microsoft/mfc-spectre/unicode/x64: [ 134, 135 ]
+      sdks/microsoft/mfc-spectre/unicode/x86: [ 136, 137 ]
       sdks/microsoft/mfc/mbcs: [ 98, 99, 100, 101, 102, 103, 104, 105, 106, 107 ]
       sdks/microsoft/mfc/mbcs/arm: [ 98, 99 ]
       sdks/microsoft/mfc/mbcs/arm64: [ 100, 101 ]
-      sdks/microsoft/mfc/mbcs/x64: [ 103, 104 ]
+      sdks/microsoft/mfc/mbcs/x64: [ 102, 105 ]
       sdks/microsoft/mfc/mbcs/x86: [ 106, 107 ]
       sdks/microsoft/mfc/unicode:
         [108,109,110,111,112,113,114,115,116,          117
         ]
       sdks/microsoft/mfc/unicode/arm: [ 108, 109 ]
       sdks/microsoft/mfc/unicode/arm64: [ 110, 111 ]
-      sdks/microsoft/mfc/unicode/x64: [ 113, 115 ]
+      sdks/microsoft/mfc/unicode/x64: [ 112, 114 ]
       sdks/microsoft/mfc/unicode/x86: [ 116, 117 ]
       sdks/microsoft/windows: [ 140, 141, 142, 143, 144 ]
-      sdks/microsoft/windows/windows: [ 140, 141, 142, 143, 144 ]
-      sdks/microsoft/windows/windows.arm: [ 141 ]
-      sdks/microsoft/windows/windows.arm64: [ 142 ]
-      sdks/microsoft/windows/windows.x64: [ 143 ]
-      sdks/microsoft/windows/windows.x86: [ 144 ]
+      sdks/microsoft/windows/windows: [ 141, 142, 143, 144 ]
+      sdks/microsoft/windows/windows.arm: [ 143 ]
+      sdks/microsoft/windows/windows.arm64: [ 141 ]
+      sdks/microsoft/windows/windows.x64: [ 144 ]
+      sdks/microsoft/windows/windows.x86: [ 142 ]
       spectre:
-        [7,8,9,10,11,12,13,14,15,16,39,40,41,42,43,44,45,46,47,48,88,89,90,91,92,93,94,95,96,97,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,48,86,87,88,89,90,91,92,93,94,95,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
-      spectre/arm: [ 7, 8, 39, 40, 88, 89 ]
-      spectre/arm64: [ 10, 11, 41, 42, 90, 91 ]
+      spectre/arm: [ 17, 18, 39, 40, 86, 87 ]
+      spectre/arm64: [ 19, 22, 41, 42, 88, 89 ]
       spectre/mbcs:
-        [120,121,122,123,124,125,126,127,128,          129
+        [118,119,120,121,122,123,124,125,126,          127
         ]
-      spectre/mbcs/arm: [ 122, 123 ]
+      spectre/mbcs/arm: [ 118, 119 ]
       spectre/mbcs/arm64: [ 120, 121 ]
-      spectre/mbcs/x64: [ 124, 125 ]
-      spectre/mbcs/x86: [ 128, 129 ]
+      spectre/mbcs/x64: [ 122, 123 ]
+      spectre/mbcs/x86: [ 126, 127 ]
       spectre/unicode:
-        [130,131,132,133,134,135,136,137,138,          139
+        [128,129,130,131,132,133,134,135,136,          137
         ]
-      spectre/unicode/arm: [ 130, 131 ]
-      spectre/unicode/arm64: [ 134, 135 ]
-      spectre/unicode/x64: [ 136, 137 ]
-      spectre/unicode/x86: [ 138, 139 ]
-      spectre/x64: [ 12, 13, 47, 48, 94, 95 ]
-      spectre/x86: [ 15, 16, 45, 46, 96, 97 ]
-      termite: [ 49 ]
-      tools: [ 49, 50, 51, 52, 57, 58, 60, 63, 64, 65 ]
-      tools/arduino: [ 50, 51 ]
-      tools/arduino/arduino: [ 50, 51 ]
+      spectre/unicode/arm: [ 128, 129 ]
+      spectre/unicode/arm64: [ 131, 133 ]
+      spectre/unicode/x64: [ 134, 135 ]
+      spectre/unicode/x86: [ 136, 137 ]
+      spectre/x64: [ 23, 24, 44, 45, 92, 93 ]
+      spectre/x86: [ 25, 26, 46, 48, 94, 95 ]
+      termite: [ 52 ]
+      tools: [ 49, 50, 51, 52, 60, 61, 62, 63, 64, 65 ]
+      tools/arduino: [ 49, 50 ]
+      tools/arduino/arduino: [ 49, 50 ]
       tools/arduino/arduino-cli: [ 50 ]
-      tools/arduino/arduino-ide: [ 51 ]
-      tools/compuphase: [ 49 ]
-      tools/compuphase/termite: [ 49 ]
-      tools/kitware: [ 52 ]
-      tools/kitware/cmake: [ 52 ]
-      tools/microsoft: [ 57, 60, 63, 64, 65 ]
-      tools/microsoft/msbuild: [ 63, 64, 65 ]
-      tools/microsoft/msbuild/vc: [ 63, 64, 65 ]
-      tools/microsoft/msbuild/vc/Desktop: [ 65 ]
-      tools/microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      tools/microsoft/msbuild/vc/uwp: [ 63 ]
-      tools/microsoft/msbuild/vc/v143: [ 64 ]
-      tools/microsoft/openocd: [ 57, 60 ]
-      tools/ninja: [ 58 ]
-      tools/ninja-build: [ 58 ]
-      tools/ninja-build/ninja: [ 58 ]
+      tools/arduino/arduino-ide: [ 49 ]
+      tools/compuphase: [ 52 ]
+      tools/compuphase/termite: [ 52 ]
+      tools/kitware: [ 51 ]
+      tools/kitware/cmake: [ 51 ]
+      tools/microsoft: [ 60, 61, 63, 64, 65 ]
+      tools/microsoft/msbuild: [ 61, 64, 65 ]
+      tools/microsoft/msbuild/vc: [ 61, 64, 65 ]
+      tools/microsoft/msbuild/vc/Desktop: [ 64 ]
+      tools/microsoft/msbuild/vc/Desktop/v143: [ 64 ]
+      tools/microsoft/msbuild/vc/uwp: [ 65 ]
+      tools/microsoft/msbuild/vc/v143: [ 61 ]
+      tools/microsoft/openocd: [ 60, 63 ]
+      tools/ninja: [ 62 ]
+      tools/ninja-build: [ 62 ]
+      tools/ninja-build/ninja: [ 62 ]
       unicode:
-        [108,109,110,111,112,113,114,115,116,117,130,131,132,133,134,135,136,137,138,          139
+        [108,109,110,111,112,113,114,115,116,117,128,129,130,131,132,133,134,135,136,          137
         ]
-      unicode/arm: [ 108, 109, 130, 131 ]
-      unicode/arm64: [ 110, 111, 134, 135 ]
-      unicode/x64: [ 113, 115, 136, 137 ]
-      unicode/x86: [ 116, 117, 138, 139 ]
-      uwp: [ 54, 61, 63, 66, 71, 72, 84 ]
-      v143: [ 56, 62, 64, 65, 67, 82, 86 ]
+      unicode/arm: [ 108, 109, 128, 129 ]
+      unicode/arm64: [ 110, 111, 131, 133 ]
+      unicode/x64: [ 112, 114, 134, 135 ]
+      unicode/x86: [ 116, 117, 136, 137 ]
+      uwp: [ 53, 59, 65, 66, 70, 72, 75 ]
+      v143: [ 56, 58, 61, 64, 69, 73, 76 ]
       v170:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       v170.arm: [ 53, 54, 56 ]
-      v170.arm.uwp: [ 54 ]
+      v170.arm.uwp: [ 53 ]
       v170.arm.v143: [ 56 ]
-      v170.arm64: [ 55, 61, 62 ]
-      v170.arm64.uwp: [ 61 ]
-      v170.arm64.v143: [ 62 ]
-      v170.arm64ec: [ 59, 66, 67 ]
+      v170.arm64: [ 55, 58, 59 ]
+      v170.arm64.uwp: [ 59 ]
+      v170.arm64.v143: [ 58 ]
+      v170.arm64ec: [ 57, 66, 69 ]
       v170.arm64ec.uwp: [ 66 ]
-      v170.arm64ec.v143: [ 67 ]
-      v170.base: [ 68, 71 ]
-      v170.base.uwp: [ 71 ]
-      v170.x64: [ 72, 74, 82 ]
+      v170.arm64ec.v143: [ 69 ]
+      v170.base: [ 67, 70 ]
+      v170.base.uwp: [ 70 ]
+      v170.x64: [ 68, 72, 73 ]
       v170.x64.uwp: [ 72 ]
-      v170.x64.v143: [ 82 ]
-      v170.x86: [ 83, 84, 86 ]
-      v170.x86.uwp: [ 84 ]
-      v170.x86.v143: [ 86 ]
+      v170.x64.v143: [ 73 ]
+      v170.x86: [ 71, 75, 76 ]
+      v170.x86.uwp: [ 75 ]
+      v170.x86.v143: [ 76 ]
       vc:
-        [53,54,55,56,59,61,62,63,64,65,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,61,64,65,66,67,68,69,70,71,72,73,75,          76
         ]
       vc.msbuild:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       vc.msbuild.v170:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       vc.msbuild.v170.arm: [ 53, 54, 56 ]
-      vc.msbuild.v170.arm.uwp: [ 54 ]
+      vc.msbuild.v170.arm.uwp: [ 53 ]
       vc.msbuild.v170.arm.v143: [ 56 ]
-      vc.msbuild.v170.arm64: [ 55, 61, 62 ]
-      vc.msbuild.v170.arm64.uwp: [ 61 ]
-      vc.msbuild.v170.arm64.v143: [ 62 ]
-      vc.msbuild.v170.arm64ec: [ 59, 66, 67 ]
+      vc.msbuild.v170.arm64: [ 55, 58, 59 ]
+      vc.msbuild.v170.arm64.uwp: [ 59 ]
+      vc.msbuild.v170.arm64.v143: [ 58 ]
+      vc.msbuild.v170.arm64ec: [ 57, 66, 69 ]
       vc.msbuild.v170.arm64ec.uwp: [ 66 ]
-      vc.msbuild.v170.arm64ec.v143: [ 67 ]
-      vc.msbuild.v170.base: [ 68, 71 ]
-      vc.msbuild.v170.base.uwp: [ 71 ]
-      vc.msbuild.v170.x64: [ 72, 74, 82 ]
+      vc.msbuild.v170.arm64ec.v143: [ 69 ]
+      vc.msbuild.v170.base: [ 67, 70 ]
+      vc.msbuild.v170.base.uwp: [ 70 ]
+      vc.msbuild.v170.x64: [ 68, 72, 73 ]
       vc.msbuild.v170.x64.uwp: [ 72 ]
-      vc.msbuild.v170.x64.v143: [ 82 ]
-      vc.msbuild.v170.x86: [ 83, 84, 86 ]
-      vc.msbuild.v170.x86.uwp: [ 84 ]
-      vc.msbuild.v170.x86.v143: [ 86 ]
-      vc/Desktop: [ 65 ]
-      vc/Desktop/v143: [ 65 ]
-      vc/uwp: [ 63 ]
-      vc/v143: [ 64 ]
+      vc.msbuild.v170.x64.v143: [ 73 ]
+      vc.msbuild.v170.x86: [ 71, 75, 76 ]
+      vc.msbuild.v170.x86.uwp: [ 75 ]
+      vc.msbuild.v170.x86.v143: [ 76 ]
+      vc/Desktop: [ 64 ]
+      vc/Desktop/v143: [ 64 ]
+      vc/uwp: [ 65 ]
+      vc/v143: [ 61 ]
       visualstudio:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       visualstudio.vc:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       visualstudio.vc.msbuild:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       visualstudio.vc.msbuild.v170:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       visualstudio.vc.msbuild.v170.arm: [ 53, 54, 56 ]
-      visualstudio.vc.msbuild.v170.arm.uwp: [ 54 ]
+      visualstudio.vc.msbuild.v170.arm.uwp: [ 53 ]
       visualstudio.vc.msbuild.v170.arm.v143: [ 56 ]
-      visualstudio.vc.msbuild.v170.arm64: [ 55, 61, 62 ]
-      visualstudio.vc.msbuild.v170.arm64.uwp: [ 61 ]
-      visualstudio.vc.msbuild.v170.arm64.v143: [ 62 ]
-      visualstudio.vc.msbuild.v170.arm64ec: [ 59, 66, 67 ]
+      visualstudio.vc.msbuild.v170.arm64: [ 55, 58, 59 ]
+      visualstudio.vc.msbuild.v170.arm64.uwp: [ 59 ]
+      visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      visualstudio.vc.msbuild.v170.arm64ec: [ 57, 66, 69 ]
       visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 66 ]
-      visualstudio.vc.msbuild.v170.arm64ec.v143: [ 67 ]
-      visualstudio.vc.msbuild.v170.base: [ 68, 71 ]
-      visualstudio.vc.msbuild.v170.base.uwp: [ 71 ]
-      visualstudio.vc.msbuild.v170.x64: [ 72, 74, 82 ]
+      visualstudio.vc.msbuild.v170.arm64ec.v143: [ 69 ]
+      visualstudio.vc.msbuild.v170.base: [ 67, 70 ]
+      visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
+      visualstudio.vc.msbuild.v170.x64: [ 68, 72, 73 ]
       visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      visualstudio.vc.msbuild.v170.x64.v143: [ 82 ]
-      visualstudio.vc.msbuild.v170.x86: [ 83, 84, 86 ]
-      visualstudio.vc.msbuild.v170.x86.uwp: [ 84 ]
-      visualstudio.vc.msbuild.v170.x86.v143: [ 86 ]
+      visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
+      visualstudio.vc.msbuild.v170.x86: [ 71, 75, 76 ]
+      visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
+      visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
       windows: [ 140, 141, 142, 143, 144 ]
-      windows.arm: [ 141 ]
-      windows.arm64: [ 142 ]
-      windows.x64: [ 143 ]
-      windows.x86: [ 144 ]
-      windows/windows: [ 140, 141, 142, 143, 144 ]
-      windows/windows.arm: [ 141 ]
-      windows/windows.arm64: [ 142 ]
-      windows/windows.x64: [ 143 ]
-      windows/windows.x86: [ 144 ]
+      windows.arm: [ 143 ]
+      windows.arm64: [ 141 ]
+      windows.x64: [ 144 ]
+      windows.x86: [ 142 ]
+      windows/windows: [ 141, 142, 143, 144 ]
+      windows/windows.arm: [ 143 ]
+      windows/windows.arm64: [ 141 ]
+      windows/windows.x64: [ 144 ]
+      windows/windows.x86: [ 142 ]
       x64:
-        [2,3,12,13,22,24,35,37,47,48,72,74,78,81,82,94,95,103,104,113,115,124,125,136,137,          143
+        [3,4,12,13,23,24,35,36,44,45,68,72,73,82,83,92,93,102,105,112,114,122,123,134,135,          144
         ]
       x64.uwp: [ 72 ]
-      x64.v143: [ 82 ]
-      x64_arm: [ 145, 148 ]
+      x64.v143: [ 73 ]
+      x64_arm: [ 148, 150 ]
       x64_arm64: [ 151, 152 ]
-      x64_x64: [ 149, 150 ]
+      x64_x64: [ 155, 156 ]
       x64_x86: [ 153, 154 ]
       x86:
-        [5,6,15,16,25,26,33,34,45,46,79,80,83,84,86,96,97,106,107,116,117,128,129,138,139,          144
+        [5,6,15,16,25,26,37,38,46,48,71,75,76,84,85,94,95,106,107,116,117,126,127,136,137,          142
         ]
-      x86.uwp: [ 84 ]
-      x86.v143: [ 86 ]
-      x86_arm: [ 155, 156 ]
-      x86_arm64: [ 161, 162 ]
-      x86_x64: [ 159, 160 ]
-      x86_x86: [ 157, 158 ]
+      x86.uwp: [ 75 ]
+      x86.v143: [ 76 ]
+      x86_arm: [ 157, 158 ]
+      x86_arm64: [ 163, 164 ]
+      x86_x64: [ 161, 162 ]
+      x86_x86: [ 159, 160 ]
   SemverKey/info.version:
     keys:
-      0.11.0-ms1: [ 60 ]
-      0.11.0: [ 57 ]
+      0.11.0-ms1: [ 63 ]
+      0.11.0: [ 60 ]
       0.18.3: [ 50 ]
-      1.10.2: [ 58 ]
-      1.18.15: [ 51 ]
-      3.4.0: [ 49 ]
-      3.20.1: [ 52 ]
+      1.10.2: [ 62 ]
+      1.18.15: [ 49 ]
+      3.4.0: [ 52 ]
+      3.20.1: [ 51 ]
       10.0.19041: [ 140, 141, 142, 143, 144 ]
-      14.28.29912: [ 28 ]
+      14.28.29912: [ 27 ]
       14.28.29914:
-        [70,75,77,80,81,87,89,90,92,94,97,98,100,102,104,106,108,111,112,113,117,118,121,122,124,127,128,131,133,134,136,          138
+        [77,79,80,83,84,87,89,90,92,95,97,98,101,104,105,107,109,110,112,115,117,119,121,122,124,126,129,130,131,134,137,          138
         ]
       14.28.29915:
-        [1,3,5,7,9,11,13,16,18,19,21,24,25,29,32,34,37,38,39,41,44,45,47,146,148,150,152,154,155,157,159,162,          163
+        [2,3,5,7,9,11,13,15,17,19,20,24,25,30,32,34,35,38,39,42,43,44,46,145,147,148,152,153,155,158,159,161,          164
         ]
       14.29.30037:
-        [2,4,6,8,10,12,14,15,17,20,22,23,26,27,30,31,33,35,36,40,42,43,46,48,69,73,76,78,79,85,88,91,93,95,96,99,101,103,105,107,109,110,114,115,116,119,120,123,125,126,129,130,132,135,137,139,145,147,149,151,153,156,158,160,161,          164
+        [1,4,6,8,10,12,14,16,18,21,22,23,26,28,29,31,33,36,37,40,41,45,47,48,74,78,81,82,85,86,88,91,93,94,96,99,100,102,103,106,108,111,113,114,116,118,120,123,125,127,128,132,133,135,136,139,146,149,150,151,154,156,157,160,162,          163
         ]
       17.0.0:
-        [53,54,55,56,59,61,62,63,64,65,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,61,64,65,66,67,68,69,70,71,72,73,75,          76
         ]
       2020.10.0: [ 0 ]
   StringKey/info.summary:
     keys:
-      Active Template Library: [ 69, 70, 73, 75, 76, 77, 78, 79, 80, 81 ]
-      Active Template Library Headers: [ 85, 87 ]
-      Active Template Library w/ Spectre mitigations: [ 88, 89, 90, 91, 92, 93, 94, 95, 96, 97 ]
-      Arduino IDE: [ 50, 51 ]
-      C runtime headers: [ 27 ]
-      C runtime headers.: [ 28 ]
-      Debug Interface Access SDK: [ 163, 164 ]
-      Free and open on-chip debugging: [ 57, 60 ]
+      Active Template Library: [ 74, 77, 78, 79, 80, 81, 82, 83, 84, 85 ]
+      Active Template Library Headers: [ 96, 97 ]
+      Active Template Library w/ Spectre mitigations: [ 86, 87, 88, 89, 90, 91, 92, 93, 94, 95 ]
+      Arduino IDE: [ 49, 50 ]
+      C runtime headers: [ 28 ]
+      C runtime headers.: [ 27 ]
+      Debug Interface Access SDK: [ 145, 146 ]
+      Free and open on-chip debugging: [ 60, 63 ]
       GCC compiler for ARM CPUs.: [ 0 ]
-      Kitware's cmake tool: [ 52 ]
+      Kitware's cmake tool: [ 51 ]
       Libraries supporting address sanitizer.: [ 1, 2, 3, 4, 5, 6 ]
-      Microsoft Foundation Classes Headers: [ 118, 119 ]
+      Microsoft Foundation Classes Headers: [ 138, 139 ]
       "Microsoft Foundation Classes, legacy MBCS libraries": [ 98, 99, 100, 101, 102, 103, 104, 105, 106, 107 ]
       "Microsoft Foundation Classes, legacy MBCS libraries w/ Spectre mitigations":
-        [120,121,122,123,124,125,126,127,128,          129
+        [118,119,120,121,122,123,124,125,126,          127
         ]
       "Microsoft Foundation Classes, Unicode":
         [108,109,110,111,112,113,114,115,116,          117
         ]
       "Microsoft Foundation Classes, Unicode w/ Spectre mitigations":
-        [130,131,132,133,134,135,136,137,138,          139
+        [128,129,130,131,132,133,134,135,136,          137
         ]
       Microsoft Windows SDK: [ 140 ]
-      Microsoft Windows SDK (targeting ARM): [ 141 ]
-      Microsoft Windows SDK (targeting ARM64): [ 142 ]
-      Microsoft Windows SDK (targeting x64): [ 143 ]
-      Microsoft Windows SDK (targeting x86): [ 144 ]
-      Msbuild support for MSVC v143 toolset: [ 64, 65 ]
-      Msbuild support for MSVC v143 toolset for UWP: [ 63 ]
+      Microsoft Windows SDK (targeting ARM): [ 143 ]
+      Microsoft Windows SDK (targeting ARM64): [ 141 ]
+      Microsoft Windows SDK (targeting x64): [ 144 ]
+      Microsoft Windows SDK (targeting x86): [ 142 ]
+      Msbuild support for MSVC v143 toolset: [ 61, 64 ]
+      Msbuild support for MSVC v143 toolset for UWP: [ 65 ]
       MSBuild support for vc projects (generated from VS install):
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
-      "MSVC standard library libraries (desktop / kernel32, + spectre)": [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
-      MSVC standard library libraries (desktop / kernel32): [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
-      MSVC standard library libraries (desktop / onecore): [ 33, 36 ]
+      "MSVC standard library libraries (desktop / kernel32, + spectre)": [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+      MSVC standard library libraries (desktop / kernel32): [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
+      MSVC standard library libraries (desktop / onecore): [ 33, 37 ]
       "MSVC standard library libraries (onecore / apisets, + spectre)": [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
-      MSVC standard library libraries (OneCore / apisets): [ 29, 30, 31, 32, 34, 35, 37, 38 ]
-      Ninja is a small build system with a focus on speed.: [ 58 ]
-      Termite is an easy to use and easy to configure RS232 terminal.: [ 49 ]
+      MSVC standard library libraries (OneCore / apisets): [ 29, 30, 31, 32, 34, 35, 36, 38 ]
+      Ninja is a small build system with a focus on speed.: [ 62 ]
+      Termite is an easy to use and easy to configure RS232 terminal.: [ 52 ]
       The Microsoft Visual C++ Compiler (MSVC):
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
     words:
-      ARM: [ 0, 141 ]
-      ARM): [ 141 ]
-      ARM64: [ 142 ]
-      ARM64): [ 142 ]
-      Access: [ 163, 164 ]
+      ARM: [ 0, 143 ]
+      ARM): [ 143 ]
+      ARM64: [ 141 ]
+      ARM64): [ 141 ]
+      Access: [ 145, 146 ]
       Active:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
-      Arduino: [ 50, 51 ]
+      Arduino: [ 49, 50 ]
       C:
-        [27,28,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [27,28,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
       CPUs: [ 0 ]
       CPUs.: [ 0 ]
@@ -735,164 +735,164 @@ indexes:
         [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
         ]
       Compiler:
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
-      Debug: [ 163, 164 ]
+      Debug: [ 145, 146 ]
       Foundation:
         [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
         ]
-      Free: [ 57, 60 ]
+      Free: [ 60, 63 ]
       GCC: [ 0 ]
-      Headers: [ 85, 87, 118, 119 ]
-      IDE: [ 50, 51 ]
-      Interface: [ 163, 164 ]
-      Kitware: [ 52 ]
-      Kitware's: [ 52 ]
+      Headers: [ 96, 97, 138, 139 ]
+      IDE: [ 49, 50 ]
+      Interface: [ 145, 146 ]
+      Kitware: [ 51 ]
+      Kitware's: [ 51 ]
       Libraries: [ 1, 2, 3, 4, 5, 6 ]
       Library:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
       MBCS:
-        [98,99,100,101,102,103,104,105,106,107,120,121,122,123,124,125,126,127,128,          129
+        [98,99,100,101,102,103,104,105,106,107,118,119,120,121,122,123,124,125,126,          127
         ]
       MSBuild:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       MSVC:
-        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,63,64,65,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,61,64,65,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
       MSVC):
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
       Microsoft:
-        [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
-      Msbuild: [ 63, 64, 65 ]
-      Ninja: [ 58 ]
-      OneCore: [ 29, 30, 31, 32, 34, 35, 37, 38 ]
-      RS232: [ 49 ]
-      SDK: [ 140, 141, 142, 143, 144, 163, 164 ]
+      Msbuild: [ 61, 64, 65 ]
+      Ninja: [ 62 ]
+      OneCore: [ 29, 30, 31, 32, 34, 35, 36, 38 ]
+      RS232: [ 52 ]
+      SDK: [ 140, 141, 142, 143, 144, 145, 146 ]
       Spectre:
-        [88,89,90,91,92,93,94,95,96,97,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [86,87,88,89,90,91,92,93,94,95,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
       Template:
-        [69,70,73,75,76,77,78,79,80,81,85,87,88,89,90,91,92,93,94,95,96,          97
+        [74,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,          97
         ]
-      Termite: [ 49 ]
+      Termite: [ 52 ]
       The:
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
-      UWP: [ 63 ]
+      UWP: [ 65 ]
       Unicode:
-        [108,109,110,111,112,113,114,115,116,117,130,131,132,133,134,135,136,137,138,          139
+        [108,109,110,111,112,113,114,115,116,117,128,129,130,131,132,133,134,135,136,          137
         ]
       VS:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       Visual:
-        [145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,          162
+        [147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,          164
         ]
       Windows: [ 140, 141, 142, 143, 144 ]
-      a: [ 58 ]
+      a: [ 62 ]
       address: [ 1, 2, 3, 4, 5, 6 ]
-      an: [ 49 ]
-      and: [ 49, 57, 60 ]
+      an: [ 52 ]
+      and: [ 52, 60, 63 ]
       apisets:
-        [29,30,31,32,34,35,37,38,39,40,41,42,43,44,45,46,47,          48
+        [29,30,31,32,34,35,36,38,39,40,41,42,43,44,45,46,47,          48
         ]
-      apisets): [ 29, 30, 31, 32, 34, 35, 37, 38 ]
-      build: [ 58 ]
-      chip: [ 57, 60 ]
-      cmake: [ 52 ]
+      apisets): [ 29, 30, 31, 32, 34, 35, 36, 38 ]
+      build: [ 62 ]
+      chip: [ 60, 63 ]
+      cmake: [ 51 ]
       compiler: [ 0 ]
-      configure: [ 49 ]
-      debugging: [ 57, 60 ]
+      configure: [ 52 ]
+      debugging: [ 60, 63 ]
       desktop:
-        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,          36
+        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,          37
         ]
-      easy: [ 49 ]
-      focus: [ 58 ]
+      easy: [ 52 ]
+      focus: [ 62 ]
       for:
-        [0,53,54,55,56,59,61,62,63,64,65,66,67,68,71,72,74,82,83,84,          86
+        [0,53,54,55,56,57,58,59,61,64,65,66,67,68,69,70,71,72,73,75,          76
         ]
       from:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       generated:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       headers: [ 27, 28 ]
-      headers.: [ 28 ]
+      headers.: [ 27 ]
       install:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       install):
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
-      is: [ 49, 58 ]
+      is: [ 52, 62 ]
       kernel32:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
-      kernel32): [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
+      kernel32): [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
       legacy:
-        [98,99,100,101,102,103,104,105,106,107,120,121,122,123,124,125,126,127,128,          129
+        [98,99,100,101,102,103,104,105,106,107,118,119,120,121,122,123,124,125,126,          127
         ]
       libraries:
-        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,98,99,100,101,102,103,104,105,106,107,120,121,122,123,124,125,126,127,128,          129
+        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,98,99,100,101,102,103,104,105,106,107,118,119,120,121,122,123,124,125,126,          127
         ]
       library:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       mitigations:
-        [88,89,90,91,92,93,94,95,96,97,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [86,87,88,89,90,91,92,93,94,95,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
-      on: [ 57, 58, 60 ]
-      on-chip: [ 57, 60 ]
+      on: [ 60, 62, 63 ]
+      on-chip: [ 60, 63 ]
       onecore:
-        [33,36,39,40,41,42,43,44,45,46,47,          48
+        [33,37,39,40,41,42,43,44,45,46,47,          48
         ]
-      onecore): [ 33, 36 ]
-      open: [ 57, 60 ]
+      onecore): [ 33, 37 ]
+      open: [ 60, 63 ]
       projects:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       runtime: [ 27, 28 ]
-      s: [ 52 ]
+      s: [ 51 ]
       sanitizer: [ 1, 2, 3, 4, 5, 6 ]
       sanitizer.: [ 1, 2, 3, 4, 5, 6 ]
-      small: [ 58 ]
+      small: [ 62 ]
       spectre:
-        [7,8,9,10,11,12,13,14,15,16,39,40,41,42,43,44,45,46,47,          48
+        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,          48
         ]
       spectre):
-        [7,8,9,10,11,12,13,14,15,16,39,40,41,42,43,44,45,46,47,          48
+        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,          48
         ]
-      speed: [ 58 ]
-      speed.: [ 58 ]
+      speed: [ 62 ]
+      speed.: [ 62 ]
       standard:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       support:
-        [53,54,55,56,59,61,62,63,64,65,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,61,64,65,66,67,68,69,70,71,72,73,75,          76
         ]
       supporting: [ 1, 2, 3, 4, 5, 6 ]
-      system: [ 58 ]
+      system: [ 62 ]
       targeting: [ 141, 142, 143, 144 ]
-      terminal: [ 49 ]
-      terminal.: [ 49 ]
-      to: [ 49 ]
-      tool: [ 52 ]
-      toolset: [ 63, 64, 65 ]
-      use: [ 49 ]
-      v143: [ 63, 64, 65 ]
+      terminal: [ 52 ]
+      terminal.: [ 52 ]
+      to: [ 52 ]
+      tool: [ 51 ]
+      toolset: [ 61, 64, 65 ]
+      use: [ 52 ]
+      v143: [ 61, 64, 65 ]
       vc:
-        [53,54,55,56,59,61,62,66,67,68,71,72,74,82,83,84,          86
+        [53,54,55,56,57,58,59,66,67,68,69,70,71,72,73,75,          76
         ]
       w:
-        [88,89,90,91,92,93,94,95,96,97,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,          139
+        [86,87,88,89,90,91,92,93,94,95,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,          137
         ]
-      with: [ 58 ]
-      x64: [ 143 ]
-      x64): [ 143 ]
-      x86: [ 144 ]
-      x86): [ 144 ]
+      with: [ 62 ]
+      x64: [ 144 ]
+      x64): [ 144 ]
+      x86: [ 142 ]
+      x86): [ 142 ]

--- a/microsoft/msvc/x64_arm/x64_arm-14.28.29915.json
+++ b/microsoft/msvc/x64_arm/x64_arm-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_arm": "."
         }
     },

--- a/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
+++ b/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
@@ -1,171 +1,175 @@
 {
-    "info": {
-        "id": "microsoft/msvc/x64_arm",
-        "version": "14.29.30037",
-        "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
-        "summary": "The Microsoft Visual C++ Compiler (MSVC)",
-        "options": [ "dependencyOnly" ]
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "exports": {
-        "tools": {
-            "CC": "cl.exe",
-            "CXX": "cl.exe",
-            "AR": "lib.exe"
-        },
-        "paths": {
-            "PATH": "."
-        },
-        "locations": {
-            "VC_ExecutablePath_x64_arm": "."
-        }
-    },
-    "demands": {
-        "not windows and not x64": {
-            "error": "This variant if for a windows x64 host"
-        },
-        "windows and x64": {
-            "install": [
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base,version=14.29.30037,chip=x64/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base.vsix"
-                    ],
-                    "sha256": "3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=cs-CZ/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.csy.vsix"
-                    ],
-                    "sha256": "857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519",
-                    "lang": "cs-CZ",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=de-DE/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.deu.vsix"
-                    ],
-                    "sha256": "1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050",
-                    "lang": "de-DE",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.enu.vsix"
-                    ],
-                    "sha256": "3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1",
-                    "lang": "en-US",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=es-ES/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.esn.vsix"
-                    ],
-                    "sha256": "a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc",
-                    "lang": "es-ES",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=fr-FR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.fra.vsix"
-                    ],
-                    "sha256": "c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7",
-                    "lang": "fr-FR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=it-IT/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ita.vsix"
-                    ],
-                    "sha256": "816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58",
-                    "lang": "it-IT",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ja-JP/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.jpn.vsix"
-                    ],
-                    "sha256": "28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d",
-                    "lang": "ja-JP",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ko-KR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.kor.vsix"
-                    ],
-                    "sha256": "38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a",
-                    "lang": "ko-KR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pl-PL/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.plk.vsix"
-                    ],
-                    "sha256": "c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654",
-                    "lang": "pl-PL",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pt-BR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ptb.vsix"
-                    ],
-                    "sha256": "e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508",
-                    "lang": "pt-BR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ru-RU/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.rus.vsix"
-                    ],
-                    "sha256": "079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530",
-                    "lang": "ru-RU",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=tr-TR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.trk.vsix"
-                    ],
-                    "sha256": "b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157",
-                    "lang": "tr-TR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-CN/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.chs.vsix"
-                    ],
-                    "sha256": "9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538",
-                    "lang": "zh-CN",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-TW/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.cht.vsix"
-                    ],
-                    "sha256": "f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf",
-                    "lang": "zh-TW",
-                    "strip": 8
-                }
-            ]
-        }
+  "info": {
+    "id": "microsoft/msvc/x64_arm",
+    "version": "14.29.30037",
+    "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
+    "summary": "The Microsoft Visual C++ Compiler (MSVC)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "exports": {
+    "tools": {
+      "CC": "cl.exe",
+      "CXX": "cl.exe",
+      "AR": "lib.exe"
+    },
+    "paths": {
+      "PATH": "."
+    },
+    "locations": {
+      "VC_ExecutablePath_x64_arm": "."
+    },
+    "properties": {
+      "VCToolArchitecture": "Native64Bit",
+      "VC_ExecutablePath_x86": "$(VC_ExecutablePath_x64_arm)"
+    }
+  },
+  "demands": {
+    "not windows and not x64": {
+      "error": "This variant if for a windows x64 host"
+    },
+    "windows and x64": {
+      "install": [
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base,version=14.29.30037,chip=x64/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base.vsix"
+          ],
+          "sha256": "3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=cs-CZ/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.csy.vsix"
+          ],
+          "sha256": "857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519",
+          "lang": "cs-CZ",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=de-DE/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.deu.vsix"
+          ],
+          "sha256": "1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050",
+          "lang": "de-DE",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.enu.vsix"
+          ],
+          "sha256": "3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1",
+          "lang": "en-US",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=es-ES/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.esn.vsix"
+          ],
+          "sha256": "a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc",
+          "lang": "es-ES",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=fr-FR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.fra.vsix"
+          ],
+          "sha256": "c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7",
+          "lang": "fr-FR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=it-IT/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ita.vsix"
+          ],
+          "sha256": "816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58",
+          "lang": "it-IT",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ja-JP/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.jpn.vsix"
+          ],
+          "sha256": "28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d",
+          "lang": "ja-JP",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ko-KR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.kor.vsix"
+          ],
+          "sha256": "38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a",
+          "lang": "ko-KR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pl-PL/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.plk.vsix"
+          ],
+          "sha256": "c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654",
+          "lang": "pl-PL",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pt-BR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ptb.vsix"
+          ],
+          "sha256": "e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508",
+          "lang": "pt-BR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ru-RU/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.rus.vsix"
+          ],
+          "sha256": "079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530",
+          "lang": "ru-RU",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=tr-TR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.trk.vsix"
+          ],
+          "sha256": "b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157",
+          "lang": "tr-TR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-CN/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.chs.vsix"
+          ],
+          "sha256": "9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538",
+          "lang": "zh-CN",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-TW/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.cht.vsix"
+          ],
+          "sha256": "f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf",
+          "lang": "zh-TW",
+          "strip": 8
+        }
+      ]
+    }
+  }
 }

--- a/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
+++ b/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_arm": "."
         }
     },

--- a/microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json
+++ b/microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_arm64": "."
         }
     },

--- a/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
+++ b/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_arm64": "."
         }
     },

--- a/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
+++ b/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
@@ -1,171 +1,175 @@
 {
-    "info": {
-        "id": "microsoft/msvc/x64_arm64",
-        "version": "14.29.30037",
-        "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
-        "summary": "The Microsoft Visual C++ Compiler (MSVC)",
-        "options": [ "dependencyOnly" ]
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "exports": {
-        "tools": {
-            "CC": "cl.exe",
-            "CXX": "cl.exe",
-            "AR": "lib.exe"
-        },
-        "paths": {
-            "PATH": "."
-        },
-        "locations": {
-            "VC_ExecutablePath_x64_arm64": "."
-        }
-    },
-    "demands": {
-        "not windows and not x64": {
-            "error": "This variant if for a windows x64 host"
-        },
-        "windows and x64": {
-            "install": [
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base,version=14.29.30037,chip=x64/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base.vsix"
-                    ],
-                    "sha256": "3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=cs-CZ/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.csy.vsix"
-                    ],
-                    "sha256": "857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519",
-                    "lang": "cs-CZ",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=de-DE/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.deu.vsix"
-                    ],
-                    "sha256": "1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050",
-                    "lang": "de-DE",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.enu.vsix"
-                    ],
-                    "sha256": "3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1",
-                    "lang": "en-US",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=es-ES/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.esn.vsix"
-                    ],
-                    "sha256": "a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc",
-                    "lang": "es-ES",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=fr-FR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.fra.vsix"
-                    ],
-                    "sha256": "c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7",
-                    "lang": "fr-FR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=it-IT/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ita.vsix"
-                    ],
-                    "sha256": "816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58",
-                    "lang": "it-IT",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ja-JP/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.jpn.vsix"
-                    ],
-                    "sha256": "28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d",
-                    "lang": "ja-JP",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ko-KR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.kor.vsix"
-                    ],
-                    "sha256": "38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a",
-                    "lang": "ko-KR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pl-PL/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.plk.vsix"
-                    ],
-                    "sha256": "c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654",
-                    "lang": "pl-PL",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pt-BR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ptb.vsix"
-                    ],
-                    "sha256": "e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508",
-                    "lang": "pt-BR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ru-RU/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.rus.vsix"
-                    ],
-                    "sha256": "079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530",
-                    "lang": "ru-RU",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=tr-TR/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.trk.vsix"
-                    ],
-                    "sha256": "b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157",
-                    "lang": "tr-TR",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-CN/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.chs.vsix"
-                    ],
-                    "sha256": "9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538",
-                    "lang": "zh-CN",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-TW/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.cht.vsix"
-                    ],
-                    "sha256": "f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf",
-                    "lang": "zh-TW",
-                    "strip": 8
-                }
-            ]
-        }
+  "info": {
+    "id": "microsoft/msvc/x64_arm64",
+    "version": "14.29.30037",
+    "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
+    "summary": "The Microsoft Visual C++ Compiler (MSVC)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "exports": {
+    "tools": {
+      "CC": "cl.exe",
+      "CXX": "cl.exe",
+      "AR": "lib.exe"
+    },
+    "paths": {
+      "PATH": "."
+    },
+    "locations": {
+      "VC_ExecutablePath_x64_arm64": "."
+    },
+    "properties": {
+      "VCToolArchitecture": "Native64Bit",
+      "VC_ExecutablePath_x86": "$(VC_ExecutablePath_x64_arm64)"
+    }
+  },
+  "demands": {
+    "not windows and not x64": {
+      "error": "This variant if for a windows x64 host"
+    },
+    "windows and x64": {
+      "install": [
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base,version=14.29.30037,chip=x64/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.base.vsix"
+          ],
+          "sha256": "3247a55eb6f20cc48fa7d731922eb637ffe56096b6482717cb96ceef81a944b4",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=cs-CZ/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.csy.vsix"
+          ],
+          "sha256": "857a60585468edd5bae1f935638c4a7fc84105967d9fd73e045111ff913ea519",
+          "lang": "cs-CZ",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=de-DE/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.deu.vsix"
+          ],
+          "sha256": "1613944db1a039fb2dcc28a45eb51eb5eec57aaaf48165779c34e001b35e9050",
+          "lang": "de-DE",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.enu.vsix"
+          ],
+          "sha256": "3d766adee8850ec3fba36cabf617e5cc0fbce8195b7694caa23fdef32dd5a8b1",
+          "lang": "en-US",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=es-ES/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.esn.vsix"
+          ],
+          "sha256": "a73c3c00d9f9006397bc54e6604b952ef3a4d6e5047d21b06f95358defdb68dc",
+          "lang": "es-ES",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=fr-FR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.fra.vsix"
+          ],
+          "sha256": "c06f62df3b3f2fd9e6f3f91249fa4a21b892d183c3431ff555965931c0f1c3c7",
+          "lang": "fr-FR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=it-IT/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ita.vsix"
+          ],
+          "sha256": "816ca2c8a08a79a3f1ac6722ec798df9b359701851794f507920575b5ddf1a58",
+          "lang": "it-IT",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ja-JP/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.jpn.vsix"
+          ],
+          "sha256": "28b6d9ccb3f2c4e9028513056d8df53c2ec836b3287bbbca132a32dd430b270d",
+          "lang": "ja-JP",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ko-KR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.kor.vsix"
+          ],
+          "sha256": "38579faf6e83e356035f2270dcc418b5438db2091a86fa89d4ee509db32b8f7a",
+          "lang": "ko-KR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pl-PL/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.plk.vsix"
+          ],
+          "sha256": "c2481fb6004f2d5e1466488f74db8a2dc84f8ddd3619d33fe91c26d1275fd654",
+          "lang": "pl-PL",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=pt-BR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.ptb.vsix"
+          ],
+          "sha256": "e718afa31482065c4378df39e52316a26ade20e6c91e37969a765b0f73c01508",
+          "lang": "pt-BR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=ru-RU/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.rus.vsix"
+          ],
+          "sha256": "079783f0e16c9f15fba67d04f296ae5a53cc5a0087d015a0134af071128a7530",
+          "lang": "ru-RU",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=tr-TR/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.trk.vsix"
+          ],
+          "sha256": "b1967ed43aa6737e213c10c151b71c16c0b92ccfc3788782937c854391161157",
+          "lang": "tr-TR",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-CN/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.chs.vsix"
+          ],
+          "sha256": "9232144f8b1a6fb76a2d39641bbd9c2e5f7c6f2fb5d7ad197b450f5d565b5538",
+          "lang": "zh-CN",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base,version=14.29.30037,chip=x64,language=zh-TW/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetARM.Resources.base.cht.vsix"
+          ],
+          "sha256": "f97f5612392415ef8b14656f61921f6832303bb70ee94f257a21479a06771caf",
+          "lang": "zh-TW",
+          "strip": 8
+        }
+      ]
+    }
+  }
 }

--- a/microsoft/msvc/x64_x64/x64_x64-14.28.29915.json
+++ b/microsoft/msvc/x64_x64/x64_x64-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_x64": "."
         }
     },

--- a/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
+++ b/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_x64": "."
         }
     },

--- a/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
+++ b/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
@@ -21,9 +21,13 @@
         "paths": {
             "PATH": "."
         },
-        "locations": {
-            "VC_ExecutablePath_x64_x64": "."
-        }
+      "locations": {
+        "VC_ExecutablePath_x64_x64": "."
+      },
+      "properties": {
+        "VCToolArchitecture": "Native64Bit",
+        "VC_ExecutablePath_x64": "$(VC_ExecutablePath_x64_x64)"
+      }
     },
     "demands": {
         "not windows and not x64": {

--- a/microsoft/msvc/x64_x86/x64_x86-14.28.29915.json
+++ b/microsoft/msvc/x64_x86/x64_x86-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x64_x86": "."
         }
     },

--- a/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
+++ b/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
@@ -22,6 +22,10 @@
     },
     "locations": {
       "VC_ExecutablePath_x64_x86": "."
+    },
+    "properties": {
+      "VCToolArchitecture": "Native64Bit",
+      "VC_ExecutablePath_x86": "$(VC_ExecutablePath_x64_x86)"
     }
   },
   "demands": {

--- a/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
+++ b/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
@@ -1,47 +1,52 @@
 {
-    "info": {
-        "id": "microsoft/msvc/x64_x86",
-        "version": "14.29.30037",
-        "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
-        "summary": "The Microsoft Visual C++ Compiler (MSVC)"
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "demands": {
-        "windows": {
-            "exports": {
-                "paths": {
-                    "PATH": ".",
-                    "VC_ExecutablePath_x64_x86": "."
-                }
-            }
-        },
-        "not windows and not x64": {
-            "error": "This variant if for a windows x64 host"
-        },
-        "x64 and target:x86": {
-            "install": [
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.base,version=14.29.30037,chip=x64/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/929136ec6dc5efd8662afe524c49962b481327acbdfd24b0aa9b295f076e8d01/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.base.vsix"
-                    ],
-                    "sha256": "929136ec6dc5efd8662afe524c49962b481327acbdfd24b0aa9b295f076e8d01",
-                    "strip": 8
-                },
-                {
-                    "unzip": [
-                        "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
-                        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/33244d399e8d1320c1236e10b25b587521d8ce772d08c6cfd25991eb3abadea4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.Resources.base.enu.vsix"
-                    ],
-                    "sha256": "33244d399e8d1320c1236e10b25b587521d8ce772d08c6cfd25991eb3abadea4",
-                    "strip": 8
-                }
-            ]
-        }
+  "info": {
+    "id": "microsoft/msvc/x64_x86",
+    "version": "14.29.30037",
+    "description": "The Microsoft Visual C++ Compiler (MSVC), linker, and other associated build tools. Combine with microsoft/cppruntime and microsoft/windowssdk for a complete development environment.",
+    "summary": "The Microsoft Visual C++ Compiler (MSVC)"
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "exports": {
+    "tools": {
+      "CC": "cl.exe",
+      "CXX": "cl.exe",
+      "AR": "lib.exe"
+    },
+    "paths": {
+      "PATH": "."
+    },
+    "locations": {
+      "VC_ExecutablePath_x64_x86": "."
+    }
+  },
+  "demands": {
+    "not windows and not x64": {
+      "error": "This variant if for a windows x64 host"
+    },
+    "x64 and target:x86": {
+      "install": [
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.base,version=14.29.30037,chip=x64/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/929136ec6dc5efd8662afe524c49962b481327acbdfd24b0aa9b295f076e8d01/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.base.vsix"
+          ],
+          "sha256": "929136ec6dc5efd8662afe524c49962b481327acbdfd24b0aa9b295f076e8d01",
+          "strip": 8
+        },
+        {
+          "unzip": [
+            "vsix:///Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.Resources.base,version=14.29.30037,chip=x64,language=en-US/payload.vsix",
+            "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/33244d399e8d1320c1236e10b25b587521d8ce772d08c6cfd25991eb3abadea4/Microsoft.VC.14.29.16.10.Tools.HostX64.TargetX86.Resources.base.enu.vsix"
+          ],
+          "sha256": "33244d399e8d1320c1236e10b25b587521d8ce772d08c6cfd25991eb3abadea4",
+          "strip": 8
+        }
+      ]
+    }
+  }
 }

--- a/microsoft/msvc/x86_arm/x86_arm-14.28.29915.json
+++ b/microsoft/msvc/x86_arm/x86_arm-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_arm": "."
         }
     },

--- a/microsoft/msvc/x86_arm/x86_arm-14.29.30037.json
+++ b/microsoft/msvc/x86_arm/x86_arm-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_arm": "."
         }
     },

--- a/microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json
+++ b/microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_arm64": "."
         }
     },

--- a/microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json
+++ b/microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_arm64": "."
         }
     },

--- a/microsoft/msvc/x86_x64/x86_x64-14.28.29915.json
+++ b/microsoft/msvc/x86_x64/x86_x64-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_x64": "."
         }
     },

--- a/microsoft/msvc/x86_x64/x86_x64-14.29.30037.json
+++ b/microsoft/msvc/x86_x64/x86_x64-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_x64": "."
         }
     },

--- a/microsoft/msvc/x86_x86/x86_x86-14.28.29915.json
+++ b/microsoft/msvc/x86_x86/x86_x86-14.28.29915.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_x86": "."
         }
     },

--- a/microsoft/msvc/x86_x86/x86_x86-14.29.30037.json
+++ b/microsoft/msvc/x86_x86/x86_x86-14.29.30037.json
@@ -21,7 +21,7 @@
         "paths": {
             "PATH": "."
         },
-        "environment": {
+        "locations": {
             "VC_ExecutablePath_x86_x86": "."
         }
     },

--- a/sdks/microsoft/atl-headers/atl-headers-14.28.29914.json
+++ b/sdks/microsoft/atl-headers/atl-headers-14.28.29914.json
@@ -14,7 +14,7 @@
         "paths": {
             "include": "."
         },
-        "environment": {
+        "locations": {
             "VC_ATLMFC_IncludePath": "."
         }
     },

--- a/sdks/microsoft/atl-headers/atl-headers-14.29.30037.json
+++ b/sdks/microsoft/atl-headers/atl-headers-14.29.30037.json
@@ -10,11 +10,16 @@
             "role": [ "publisher" ]
         }
     },
+    "requires": {
+        "crts/microsoft/headers": "14.29.30037"
+    },
     "exports": {
         "paths": {
-            "include": ".",
-            "requires": "",
-            "crts/microsoft/headers": "14.29.30037"
+            "include": "."
+        },
+        "locations": {
+            "VC_ATLMFC_IncludePath": ".",
+            "VC_ATL_IncludePath": "."
         }
     },
     "install": [

--- a/sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json
+++ b/sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json
+++ b/sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json
+++ b/sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM64_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json
+++ b/sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM64_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json
+++ b/sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x64_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json
+++ b/sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x64_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json
+++ b/sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x86_spectre": "."
         }
     },

--- a/sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json
+++ b/sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x86_spectre": "."
         }
     },

--- a/sdks/microsoft/atl/arm/arm-14.28.29914.json
+++ b/sdks/microsoft/atl/arm/arm-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM": "."
         }
     },

--- a/sdks/microsoft/atl/arm/arm-14.29.30037.json
+++ b/sdks/microsoft/atl/arm/arm-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM": "."
         }
     },

--- a/sdks/microsoft/atl/arm64/arm64-14.28.29914.json
+++ b/sdks/microsoft/atl/arm64/arm64-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM64": "."
         }
     },

--- a/sdks/microsoft/atl/arm64/arm64-14.29.30037.json
+++ b/sdks/microsoft/atl/arm64/arm64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_ARM64": "."
         }
     },

--- a/sdks/microsoft/atl/x64/x64-14.28.29914.json
+++ b/sdks/microsoft/atl/x64/x64-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x64": "."
         }
     },

--- a/sdks/microsoft/atl/x64/x64-14.29.30037.json
+++ b/sdks/microsoft/atl/x64/x64-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x64": "."
         }
     },

--- a/sdks/microsoft/atl/x86/x86-14.28.29914.json
+++ b/sdks/microsoft/atl/x86/x86-14.28.29914.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x86": "."
         }
     },

--- a/sdks/microsoft/atl/x86/x86-14.29.30037.json
+++ b/sdks/microsoft/atl/x86/x86-14.29.30037.json
@@ -15,7 +15,7 @@
         "paths": {
             "lib": "."
         },
-        "environment": {
+        "locations": {
             "VC_LibraryPath_ATL_x86": "."
         }
     },

--- a/sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json
+++ b/sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json
@@ -1,31 +1,37 @@
 {
-    "info": {
-        "id": "sdks/microsoft/mfc-headers",
-        "version": "14.29.30037",
-        "summary": "Microsoft Foundation Classes Headers"
+  "info": {
+    "id": "sdks/microsoft/mfc-headers",
+    "version": "14.29.30037",
+    "summary": "Microsoft Foundation Classes Headers"
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
+    }
+  },
+  "requires": {
+    "sdks/microsoft/atl-headers": "14.29.30037"
+  },
+  "exports": {
+    "paths": {
+      "include": "."
     },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
+    "locations": {
+      "VC_MFC_IncludePath": "."
     },
-    "exports": {
-        "paths": {
-            "include": ".",
-            "requires": "",
-            "crts/microsoft/headers": "14.29.30037",
-            "sdks/microsoft/atl-headers": "14.29.30037"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.MFC.Headers.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/754f9e2e4d46d6b3cbfaa7beec30af37f4570e3cc063785a985d96535832d3c7/Microsoft.VC.14.29.16.10.MFC.Headers.base.vsix"
-            ],
-            "sha256": "754f9e2e4d46d6b3cbfaa7beec30af37f4570e3cc063785a985d96535832d3c7",
-            "strip": 7
-        }
-    ]
+    "properties": {
+      "VC_ATLMFC_IncludePath": "$(VC_MFC_IncludePath);$(VC_ATLMFC_IncludePath)"
+    }
+  },
+  "install": [
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.MFC.Headers.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/754f9e2e4d46d6b3cbfaa7beec30af37f4570e3cc063785a985d96535832d3c7/Microsoft.VC.14.29.16.10.MFC.Headers.base.vsix"
+      ],
+      "sha256": "754f9e2e4d46d6b3cbfaa7beec30af37f4570e3cc063785a985d96535832d3c7",
+      "strip": 7
+    }
+  ]
 }

--- a/sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json
+++ b/sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json
@@ -1,39 +1,37 @@
 {
-    "info": {
-        "id": "sdks/microsoft/mfc/unicode/arm",
-        "version": "14.29.30037",
-        "summary": "Microsoft Foundation Classes, Unicode",
-        "options": [ "dependencyOnly" ]
+  "info": {
+    "id": "sdks/microsoft/mfc/unicode/arm",
+    "version": "14.29.30037",
+    "summary": "Microsoft Foundation Classes, Unicode",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
+    }
+  },
+  "exports": {
+    "paths": {
+      "lib": "."
+    }
+  },
+  "install": [
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.MFC.ARM.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/14d5eef106ade93b22c6f21e70b58731a8d9bdbcab73fee9d9234dc295fcea38/Microsoft.VC.14.29.16.10.MFC.ARM.base.vsix"
+      ],
+      "sha256": "14d5eef106ade93b22c6f21e70b58731a8d9bdbcab73fee9d9234dc295fcea38",
+      "strip": 8
     },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "exports": {
-        "paths": {
-            "lib": ".",
-            "requires": "",
-            "crts/microsoft/headers": "14.29.30037"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.MFC.ARM.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/14d5eef106ade93b22c6f21e70b58731a8d9bdbcab73fee9d9234dc295fcea38/Microsoft.VC.14.29.16.10.MFC.ARM.base.vsix"
-            ],
-            "sha256": "14d5eef106ade93b22c6f21e70b58731a8d9bdbcab73fee9d9234dc295fcea38",
-            "strip": 8
-        },
-        {
-            "unzip": [
-                "vsix:///Microsoft.VC.14.29.16.10.MFC.ARM.Debug.base,version=14.29.30037/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/4a834eea743f512f4d0726ab74fd58b587cf395ee76fc3ee326d2adc9ec76fc9/Microsoft.VC.14.29.16.10.MFC.ARM.Debug.base.vsix"
-            ],
-            "sha256": "4a834eea743f512f4d0726ab74fd58b587cf395ee76fc3ee326d2adc9ec76fc9",
-            "strip": 8
-        }
-    ]
+    {
+      "unzip": [
+        "vsix:///Microsoft.VC.14.29.16.10.MFC.ARM.Debug.base,version=14.29.30037/payload.vsix",
+        "https://download.visualstudio.microsoft.com/download/pr/c0ac19c1-e1d7-47e2-bde8-fd11c4410cca/4a834eea743f512f4d0726ab74fd58b587cf395ee76fc3ee326d2adc9ec76fc9/Microsoft.VC.14.29.16.10.MFC.ARM.Debug.base.vsix"
+      ],
+      "sha256": "4a834eea743f512f4d0726ab74fd58b587cf395ee76fc3ee326d2adc9ec76fc9",
+      "strip": 8
+    }
+  ]
 }

--- a/sdks/microsoft/mfc/unicode/unicode-14.29.30037.json
+++ b/sdks/microsoft/mfc/unicode/unicode-14.29.30037.json
@@ -1,35 +1,38 @@
 {
-    "info": {
-        "id": "sdks/microsoft/mfc/unicode",
-        "version": "14.29.30037",
-        "summary": "Microsoft Foundation Classes, Unicode"
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "demands": {
-        "target:x86": {
-            "requires": {
-                "sdks/microsoft/mfc/unicode/x86": "14.29.30037"
-            }
-        },
-        "target:x64": {
-            "requires": {
-                "sdks/microsoft/mfc/unicode/x64": "14.29.30037"
-            }
-        },
-        "target:arm": {
-            "requires": {
-                "sdks/microsoft/mfc/unicode/arm": "14.29.30037"
-            }
-        },
-        "target:arm64": {
-            "requires": {
-                "sdks/microsoft/mfc/unicode/arm64": "14.29.30037"
-            }
-        }
+  "info": {
+    "id": "sdks/microsoft/mfc/unicode",
+    "version": "14.29.30037",
+    "summary": "Microsoft Foundation Classes, Unicode"
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "requires": {
+    "crts/microsoft/headers": "14.29.30037"
+  },
+  "demands": {
+    "target:x86": {
+      "requires": {
+        "sdks/microsoft/mfc/unicode/x86": "14.29.30037"
+      }
+    },
+    "target:x64": {
+      "requires": {
+        "sdks/microsoft/mfc/unicode/x64": "14.29.30037"
+      }
+    },
+    "target:arm": {
+      "requires": {
+        "sdks/microsoft/mfc/unicode/arm": "14.29.30037"
+      }
+    },
+    "target:arm64": {
+      "requires": {
+        "sdks/microsoft/mfc/unicode/arm64": "14.29.30037"
+      }
+    }
+  }
 }

--- a/sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json
+++ b/sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json
@@ -13,9 +13,7 @@
     },
     "exports": {
         "paths": {
-            "lib": ".",
-            "requires": "",
-            "crts/microsoft/headers": "14.29.30037"
+            "lib": "."
         }
     },
     "install": [

--- a/sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json
+++ b/sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json
@@ -13,9 +13,7 @@
     },
     "exports": {
         "paths": {
-            "lib": ".",
-            "requires": "",
-            "crts/microsoft/headers": "14.29.30037"
+            "lib": "."
         }
     },
     "install": [

--- a/sdks/microsoft/windows/windows-10.0.19041.json
+++ b/sdks/microsoft/windows/windows-10.0.19041.json
@@ -1,56 +1,68 @@
 {
-    "info": {
-        "id": "sdks/microsoft/windows",
-        "version": "10.0.19041",
-        "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
-        "summary": "Microsoft Windows SDK"
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.cpp/10.0.19041.5"
-            ],
-            "sha256": "35074cafacc99a47e87c25641f98e0952576487fe29607103f83d61540ad0523"
-        }
-    ],
-    "demands": {
-        "windows and target:arm": {
-            "requires": {
-                "sdks/microsoft/windows/windows.arm": "10.0.19041"
-            }
-        },
-        "windows and target:arm64": {
-            "requires": {
-                "sdks/microsoft/windows/windows.arm64": "10.0.19041"
-            }
-        },
-        "windows and target:x64": {
-            "requires": {
-                "sdks/microsoft/windows/windows.x64": "10.0.19041"
-            }
-        },
-        "windows and target:x86": {
-            "requires": {
-                "sdks/microsoft/windows/windows.x86": "10.0.19041"
-            }
-        }
-    },
-    "exports": {
-        "paths": {
-            "include": [
-                "./c/Include/10.0.19041.0/cppwinrt",
-                "./c/Include/10.0.19041.0/shared",
-                "./c/Include/10.0.19041.0/ucrt",
-                "./c/Include/10.0.19041.0/um",
-                "./c/Include/10.0.19041.0/winrt"
-            ],
-            "PATH": "./bin"
-        }
+  "info": {
+    "id": "sdks/microsoft/windows",
+    "version": "10.0.19041",
+    "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
+    "summary": "Microsoft Windows SDK"
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "install": [
+    {
+      "unzip": [
+        "https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.cpp/10.0.19041.5"
+      ],
+      "sha256": "35074cafacc99a47e87c25641f98e0952576487fe29607103f83d61540ad0523"
+    }
+  ],
+  "demands": {
+    "windows and target:arm": {
+      "requires": {
+        "sdks/microsoft/windows/windows.arm": "10.0.19041"
+      }
+    },
+    "windows and target:arm64": {
+      "requires": {
+        "sdks/microsoft/windows/windows.arm64": "10.0.19041"
+      }
+    },
+    "windows and target:x64": {
+      "requires": {
+        "sdks/microsoft/windows/windows.x64": "10.0.19041"
+      }
+    },
+    "windows and target:x86": {
+      "requires": {
+        "sdks/microsoft/windows/windows.x86": "10.0.19041"
+      }
+    }
+  },
+  "exports": {
+    "paths": {
+      "include": [
+        "./c/Include/10.0.19041.0/cppwinrt",
+        "./c/Include/10.0.19041.0/shared",
+        "./c/Include/10.0.19041.0/ucrt",
+        "./c/Include/10.0.19041.0/um",
+        "./c/Include/10.0.19041.0/winrt"
+      ],
+      "PATH": "./bin"
+    },
+    "locations": {
+      "_WindowsSdkDir_10": "./c",
+      "_UCRTContentRoot": "./c"
+    },
+    "properties": {
+      "TargetPlatformVersion": "10.0.19041.0",
+      "WindowsSdkDir_10": "$(_WindowsSdkDir_10)\\",
+      "WindowsSdkDir": "$(WindowsSdkDir_10)",
+      "UCRTContentRoot": "$(_UCRTContentRoot)\\",
+      "UniversalCRTSdkDir_10": "$(UCRTContentRoot)",
+      "UniversalCRTSdkDir": "$(UCRTContentRoot)"
+    }
+  }
 }

--- a/sdks/microsoft/windows/windows-10.0.19041.json
+++ b/sdks/microsoft/windows/windows-10.0.19041.json
@@ -53,16 +53,47 @@
       "PATH": "./bin"
     },
     "locations": {
-      "_WindowsSdkDir_10": "./c",
-      "_UCRTContentRoot": "./c"
+      "UM_IncludePath": ".\\c\\Include\\10.0.19041.0\\um",
+      "KIT_SHARED_IncludePath": ".\\c\\Include\\10.0.19041.0\\shared",
+      "WinRT_IncludePath": ".\\c\\Include\\10.0.19041.0\\winrt",
+      "CppWinRT_IncludePath": ".\\c\\Include\\10.0.19041.0\\cppwinrt",
+      "WindowsSDK_MetadataFoundationPath": ".\\c\\References\\10.0.19041.0\\windows.foundation.foundationcontract\\4.0.0.0",
+      "WindowsSDK_MetadataPath": ".\\c\\References",
+      "WindowsSDK_MetadataPathVersioned": ".\\c\\References\\\\10.0.19041.0",
+
+      "WindowsSDK_PlatformPath": ".\\c\\Platforms\\UAP",
+      "WindowsSDK_UnionMetadataPath": ".\\c\\UnionMetadata\\10.0.19041.0",
+
+      "WindowsSDK_ExecutablePath_x86": ".\\c\\bin\\10.0.19041.0\\x86;",
+      "WindowsSDK_SupportedAPIs_x64": ".\\c\\bin\\10.0.19041.0\\x64\\PInvoke\\SupportedAPIs.xml",
+
+      "WindowsSDK_ExecutablePath_x64": ".\\c\\bin\\10.0.19041.0\\x64;",
+      "WindowsSDK_SupportedAPIs_x86": ".\\c\\bin\\10.0.19041.0\\x86\\PInvoke\\SupportedAPIs.xml",
+
+      "WindowsSDK_ExecutablePath_arm": ".\\c\\bin\\10.0.19041.0\\arm;",
+      "WindowsSDK_SupportedAPIs_arm": ".\\c\\bin\\10.0.19041.0\\arm\\PInvoke\\SupportedAPIs.xml",
+
+      "WindowsSDK_ExecutablePath_arm64": ".\\c\\bin\\10.0.19041.0\\arm64;",
+      "WindowsSDK_SupportedAPIs_arm64": ".\\c\\bin\\10.0.19041.0\\arm64\\PInvoke\\SupportedAPIs.xml",
+
+      "UniversalDebugCRT_ExecutablePath_x86": ".\\c\\bin\\10.0.19041.0\\x86\\ucrt",
+      "UniversalDebugCRT_ExecutablePath_x64": ".\\c\\bin\\10.0.19041.0\\x64\\ucrt",
+      "UniversalDebugCRT_ExecutablePath_ARM": ".\\c\\bin\\10.0.19041.0\\ARM\\ucrt",
+      "UniversalDebugCRT_ExecutablePath_ARM64": ".\\c\\bin\\10.0.19041.0\\ARM64\\ucrt",
+
+      "UniversalCRT_IncludePath": ".\\c\\Include\\10.0.19041.0\\ucrt;",
+      "UniversalCRT_SourcePath": ".\\c\\Source\\10.0.19041.0\\ucrt;",
     },
     "properties": {
       "WindowsTargetPlatformVersion": "10.0.19041.0",
-      "WindowsSdkDir_10": "$(_WindowsSdkDir_10)\\",
+      "WindowsSdkDir_10": "WindowsSdkDir_10_not_defined\\",
       "WindowsSdkDir": "$(WindowsSdkDir_10)",
       "UCRTContentRoot": "$(_UCRTContentRoot)\\",
-      "UniversalCRTSdkDir_10": "$(UCRTContentRoot)",
-      "UniversalCRTSdkDir": "$(UCRTContentRoot)"
+      "UniversalCRTSdkDir_10": "UniversalCRTSdkDir_10_not_defined\\",
+
+      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
+      "WindowsSDK_HasVersionedContent": "true"
+
     }
   }
 }

--- a/sdks/microsoft/windows/windows-10.0.19041.json
+++ b/sdks/microsoft/windows/windows-10.0.19041.json
@@ -57,7 +57,7 @@
       "_UCRTContentRoot": "./c"
     },
     "properties": {
-      "TargetPlatformVersion": "10.0.19041.0",
+      "WindowsTargetPlatformVersion": "10.0.19041.0",
       "WindowsSdkDir_10": "$(_WindowsSdkDir_10)\\",
       "WindowsSdkDir": "$(WindowsSdkDir_10)",
       "UCRTContentRoot": "$(_UCRTContentRoot)\\",

--- a/sdks/microsoft/windows/windows-10.0.19041.json
+++ b/sdks/microsoft/windows/windows-10.0.19041.json
@@ -82,7 +82,7 @@
       "UniversalDebugCRT_ExecutablePath_ARM64": ".\\c\\bin\\10.0.19041.0\\ARM64\\ucrt",
 
       "UniversalCRT_IncludePath": ".\\c\\Include\\10.0.19041.0\\ucrt;",
-      "UniversalCRT_SourcePath": ".\\c\\Source\\10.0.19041.0\\ucrt;",
+      "UniversalCRT_SourcePath": ".\\c\\Source\\10.0.19041.0\\ucrt;"
     },
     "properties": {
       "WindowsTargetPlatformVersion": "10.0.19041.0",
@@ -93,7 +93,6 @@
 
       "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_HasVersionedContent": "true"
-
     }
   }
 }

--- a/sdks/microsoft/windows/windows.x64-10.0.19041.json
+++ b/sdks/microsoft/windows/windows.x64-10.0.19041.json
@@ -1,38 +1,36 @@
 {
-    "info": {
-        "id": "sdks/microsoft/windows/windows.x64",
-        "version": "10.0.19041",
-        "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications (targeting x64).",
-        "summary": "Microsoft Windows SDK (targeting x64)",
-        "options": [ "dependencyOnly" ]
-    },
-    "contacts": {
-        "Mark Levine": {
-            "email": "markle@microsoft.com",
-            "role": [ "publisher" ]
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.cpp.x64/10.0.19041.5"
-            ],
-            "sha256": "EE8B7BC43ED58D17BE795C8062AD32E355847AADAD7DC8096CC04CCD1F2FDC2E"
-        }
-    ],
-    "exports": {
-        "paths": {
-            "LIB": [
-                "./c/ucrt/x64",
-                "./c/um/x64"
-            ],
-            "PATH": "./bin"
-        },
-        "locations": {
-            "WindowsSDK_LibraryPath_x64": [
-                "./c/ucrt/x64",
-                "./c/um/x64"
-            ]
-        }
+  "info": {
+    "id": "sdks/microsoft/windows/windows.x64",
+    "version": "10.0.19041",
+    "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications (targeting x64).",
+    "summary": "Microsoft Windows SDK (targeting x64)",
+    "options": [ "dependencyOnly" ]
+  },
+  "contacts": {
+    "Mark Levine": {
+      "email": "markle@microsoft.com",
+      "role": [ "publisher" ]
     }
+  },
+  "install": [
+    {
+      "unzip": [
+        "https://www.nuget.org/api/v2/package/Microsoft.Windows.SDK.cpp.x64/10.0.19041.5"
+      ],
+      "sha256": "EE8B7BC43ED58D17BE795C8062AD32E355847AADAD7DC8096CC04CCD1F2FDC2E"
+    }
+  ],
+  "exports": {
+    "paths": {
+      "LIB": [
+        "./c/ucrt/x64",
+        "./c/um/x64"
+      ],
+      "PATH": "./bin"
+    },
+    "locations": {
+      "WindowsSDK_LibraryPath_x64": "./c/um/x64",
+      "UniversalCRT_LibraryPath_x64": "./c/ucrt/x64"
+    }
+  }
 }

--- a/sdks/microsoft/windows/windows.x64-10.0.19041.json
+++ b/sdks/microsoft/windows/windows.x64-10.0.19041.json
@@ -28,7 +28,7 @@
             ],
             "PATH": "./bin"
         },
-        "environment": {
+        "locations": {
             "WindowsSDK_LibraryPath_x64": [
                 "./c/ucrt/x64",
                 "./c/um/x64"

--- a/sdks/microsoft/windows/windows.x86-10.0.19041.json
+++ b/sdks/microsoft/windows/windows.x86-10.0.19041.json
@@ -28,11 +28,9 @@
             ],
             "PATH": "./bin"
         },
-        "locations": {
-            "WindowsSDK_LibraryPath_x86": [
-                "./c/ucrt/x86",
-                "./c/um/x86"
-            ]
-        }
+      "locations": {
+        "WindowsSDK_LibraryPath_x86": "./c/um/x86",
+        "UniversalCRT_LibraryPath_x86": "./c/ucrt/x86"
+      }
     }
 }

--- a/sdks/microsoft/windows/windows.x86-10.0.19041.json
+++ b/sdks/microsoft/windows/windows.x86-10.0.19041.json
@@ -28,7 +28,7 @@
             ],
             "PATH": "./bin"
         },
-        "environment": {
+        "locations": {
             "WindowsSDK_LibraryPath_x86": [
                 "./c/ucrt/x86",
                 "./c/um/x86"

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json
@@ -15,8 +15,8 @@
 		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
 	},
 	"exports": {
-		"environment": {
-			"PlatformDirectory" : ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM"
+		"locations": {
+			"PlatformDirectory" : "."
 		}
 	},
 	"install": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/8bf9d472b509c5a4b174c451dc32b3bc80f651ec4d43afa311a0b38d3e9451ef/payload.vsix"
 			],
 			"sha256": "8bf9d472b509c5a4b174c451dc32b3bc80f651ec4d43afa311a0b38d3e9451ef",
-			"strip": 1
+			"strip": 7
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json
@@ -15,9 +15,9 @@
 		"microsoft.visualstudio.vc.msbuild.v170.base.uwp": "17.0.0"
 	},
 	"exports": {
-		"environment": {
-			"PlatformDirectory" : ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM",
-			"ToolsetDirectory" : ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM\\PlatformToolsets\\v143"
+		"locations": {
+			"PlatformDirectory" : ".",
+			"ToolsetDirectory" : ".\\PlatformToolsets\\v143"
 		}
 	},
 	"install": [
@@ -27,7 +27,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/becd641486f0f9ac3f7828dfcab26d1c1c201a9244be5f4e426e58cb0937369e/payload.vsix"
 			],
 			"sha256": "becd641486f0f9ac3f7828dfcab26d1c1c201a9244be5f4e426e58cb0937369e",
-			"strip": 1
+			"strip": 10
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.arm": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"ToolsetDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/c69413d4b093b41f925c1dd13860aa4c7354ec9d157aaf2736eeb6224f67619d/payload.vsix"
 			],
 			"sha256": "c69413d4b093b41f925c1dd13860aa4c7354ec9d157aaf2736eeb6224f67619d",
-			"strip": 1
+			"strip": 9
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM64"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/b5ede32fc2859122e277e01021757d3c7caa61034c28427770302844a91fc428/payload.vsix"
 			],
 			"sha256": "b5ede32fc2859122e277e01021757d3c7caa61034c28427770302844a91fc428",
-			"strip": 1
+			"strip": 7
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json
@@ -14,12 +14,12 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base.uwp": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM64",
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM64\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : ".",
+			"ToolsetDirectory" : ".\\PlatformToolsets\\v143"
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -27,7 +27,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/ce12ebfe0fe57058e6d31964571cab83619c52b05943ba5c4933b4823ade6744/payload.vsix"
 			],
 			"sha256": "ce12ebfe0fe57058e6d31964571cab83619c52b05943ba5c4933b4823ade6744",
-			"strip": 1
+			"strip": 10
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.arm64": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM64\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"ToolsetDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/5b9d3c04272e9c8ddb307bca4c9f29bdb2c1304473220dc21c52a98de993ac5e/payload.vsix"
 			],
 			"sha256": "5b9d3c04272e9c8ddb307bca4c9f29bdb2c1304473220dc21c52a98de993ac5e",
-			"strip": 1
+			"strip": 9
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM64EC"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/7311b6da2a6113c7d04c34bfdfe72eda05e35df46d33ec01d79b56e69e811158/payload.vsix"
 			],
 			"sha256": "7311b6da2a6113c7d04c34bfdfe72eda05e35df46d33ec01d79b56e69e811158",
-			"strip": 1
+			"strip": 7
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json
@@ -14,12 +14,12 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base.uwp": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM64EC",
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\ARM64EC\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : ".",
+			"ToolsetDirectory" : ".\\PlatformToolsets\\v143"
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -27,7 +27,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/d98f4c91815dd10b1c5177137625e327b3ede6a02b7c31524fd1c6c604909c64/payload.vsix"
 			],
 			"sha256": "d98f4c91815dd10b1c5177137625e327b3ede6a02b7c31524fd1c6c604909c64",
-			"strip": 1
+			"strip": 10
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json
@@ -1,32 +1,32 @@
 {
-    "info": {
-        "id": "microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143",
-        "version": "17.0.0",
-        "description": "MSBuild support for vc projects (generated from VS install)",
-        "summary": "MSBuild support for vc projects (generated from VS install)"
-    },
-    "contacts": {
-        "Olga Arkhipova": {
-            "email": "olgaark@microsoft.com",
-            "role": "publisher"
-        }
-    },
-    "requires": {
-        "microsoft.visualstudio.vc.msbuild.v170.arm64ec": "17.0.0"
-    },
-    "exports": {
-        "environment": {
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\ARM64EC\\PlatformToolsets\\v143"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143,version=17.0.0,productArch=neutral/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/25d8db367f6cb2f483365340ee0826c84c5ce6756885db42d28f5be68b3c314d/payload.vsix"
-            ],
-            "sha256": "25d8db367f6cb2f483365340ee0826c84c5ce6756885db42d28f5be68b3c314d",
-            "strip": 1
-        }
-    ]
+	"info": {
+		"id": "microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143",
+		"version": "17.0.0",
+		"description": "MSBuild support for vc projects (generated from VS install)",
+		"summary": "MSBuild support for vc projects (generated from VS install)"
+	}, 
+	"contacts": {
+		"Olga Arkhipova": {
+			"email": "olgaark@microsoft.com",
+			"role": "publisher"
+		}
+	},
+	"requires": {
+		"microsoft.visualstudio.vc.msbuild.v170.arm64ec": "17.0.0"
+	},
+	"exports": {
+		"locations": {
+			"ToolsetDirectory" : "."
+		}
+	},
+	"install": [
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143,version=17.0.0,productArch=neutral/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/25d8db367f6cb2f483365340ee0826c84c5ce6756885db42d28f5be68b3c314d/payload.vsix"
+			],
+			"sha256": "25d8db367f6cb2f483365340ee0826c84c5ce6756885db42d28f5be68b3c314d",
+			"strip": 9
+		}
+	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json
@@ -1,159 +1,159 @@
 {
-    "info": {
-        "id": "microsoft.visualstudio.vc.msbuild.v170.base",
-        "version": "17.0.0",
-        "description": "MSBuild support for vc projects (generated from VS install)",
-        "summary": "MSBuild support for vc projects (generated from VS install)"
-    },
-    "contacts": {
-        "Olga Arkhipova": {
-            "email": "olgaark@microsoft.com",
-            "role": "publisher"
-        }
-    },
-    "exports": {
-        "environment": {
-            "VCTargetsPath17": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\"
-        },
-        "properties": {
-            "VcpkgInstalledVCTargets": "true",
-            "DisableInstalledVCTargetsUse": "true"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/6d5f5c0638b80748cbd5b87a21852dcbde9e18418ec53e5d53c2fbd28d0e6b03/payload.vsix"
-            ],
-            "sha256": "6d5f5c0638b80748cbd5b87a21852dcbde9e18418ec53e5d53c2fbd28d0e6b03",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=cs-CZ/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/3f5b60913c2734488ac7865190e00a0d1a039e5e607d98cb91ccbe8dd73ba664/payload.vsix"
-            ],
-            "sha256": "3f5b60913c2734488ac7865190e00a0d1a039e5e607d98cb91ccbe8dd73ba664",
-            "lang": "cs-CZ",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=de-DE/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f28dd4303c725d643b67a7281f4896d282588b0a02ad0478f7c66fc94b2c2a60/payload.vsix"
-            ],
-            "sha256": "f28dd4303c725d643b67a7281f4896d282588b0a02ad0478f7c66fc94b2c2a60",
-            "lang": "de-DE",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=en-US/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/dd04c0ac51bbe186b0c3089a895277ac6e583d35947153f119992b276044110e/payload.vsix"
-            ],
-            "sha256": "dd04c0ac51bbe186b0c3089a895277ac6e583d35947153f119992b276044110e",
-            "lang": "en-US",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=es-ES/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/5f76200bee344972a90474fc9c546ba837e46ba0b3fe84577005acc0431849ad/payload.vsix"
-            ],
-            "sha256": "5f76200bee344972a90474fc9c546ba837e46ba0b3fe84577005acc0431849ad",
-            "lang": "es-ES",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=fr-FR/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/69810b21b9016f5455034255b70342a301b143819574754fe1a7cb69df99c1fd/payload.vsix"
-            ],
-            "sha256": "69810b21b9016f5455034255b70342a301b143819574754fe1a7cb69df99c1fd",
-            "lang": "fr-FR",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=it-IT/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/7ec697c9b838c3083a4c07e66d72dafaad10f9e14ed4d32a8e65fcdef1868c78/payload.vsix"
-            ],
-            "sha256": "7ec697c9b838c3083a4c07e66d72dafaad10f9e14ed4d32a8e65fcdef1868c78",
-            "lang": "it-IT",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ja-JP/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/4df89bec0c2003a66bafd695ae338fc53424ff0ceb9ec948cd161a3111d61aa4/payload.vsix"
-            ],
-            "sha256": "4df89bec0c2003a66bafd695ae338fc53424ff0ceb9ec948cd161a3111d61aa4",
-            "lang": "ja-JP",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ko-KR/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f41018ce193605929fc1a90af6e464ec6dcae2128fb3a5cd928d4ec305f6b516/payload.vsix"
-            ],
-            "sha256": "f41018ce193605929fc1a90af6e464ec6dcae2128fb3a5cd928d4ec305f6b516",
-            "lang": "ko-KR",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=pl-PL/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/bd6343fe2e38434d8a1f3d75f712a0ad0966e7331c04f3d84e61799e6f7e121a/payload.vsix"
-            ],
-            "sha256": "bd6343fe2e38434d8a1f3d75f712a0ad0966e7331c04f3d84e61799e6f7e121a",
-            "lang": "pl-PL",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=pt-BR/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/15b9da8cf7a2e01ed3ce70118182f53728d6d44f660202a85ffafc1b0ccbf1d6/payload.vsix"
-            ],
-            "sha256": "15b9da8cf7a2e01ed3ce70118182f53728d6d44f660202a85ffafc1b0ccbf1d6",
-            "lang": "pt-BR",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ru-RU/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/4202d7bb7a6c26594e271fea0a720e1efcfea1cfb7868384d04dce4205309a13/payload.vsix"
-            ],
-            "sha256": "4202d7bb7a6c26594e271fea0a720e1efcfea1cfb7868384d04dce4205309a13",
-            "lang": "ru-RU",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=tr-TR/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f2f13c0497f89d1a7f6f91e4412805a1a63bb9d1ef23af6c3b17fec54368a730/payload.vsix"
-            ],
-            "sha256": "f2f13c0497f89d1a7f6f91e4412805a1a63bb9d1ef23af6c3b17fec54368a730",
-            "lang": "tr-TR",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=zh-CN/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/2b5bede7848422caec5787b4eccf9e5b382b5d7aa55ce24f22c73295cd942497/payload.vsix"
-            ],
-            "sha256": "2b5bede7848422caec5787b4eccf9e5b382b5d7aa55ce24f22c73295cd942497",
-            "lang": "zh-CN",
-            "strip": 1
-        },
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=zh-TW/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/32f042164bc0f1a6546e1194a731b4dcf83152bbf5bb18a1565e5c9b02393714/payload.vsix"
-            ],
-            "sha256": "32f042164bc0f1a6546e1194a731b4dcf83152bbf5bb18a1565e5c9b02393714",
-            "lang": "zh-TW",
-            "strip": 1
-        }
-    ]
+	"info": {
+		"id": "microsoft.visualstudio.vc.msbuild.v170.base",
+		"version": "17.0.0",
+		"description": "MSBuild support for vc projects (generated from VS install)",
+		"summary": "MSBuild support for vc projects (generated from VS install)"
+	}, 
+	"contacts": {
+		"Olga Arkhipova": {
+			"email": "olgaark@microsoft.com",
+			"role": "publisher"
+		}
+	},
+	"exports": {
+		"locations": {
+			"VCTargetsPath17" : ".\\"
+		},
+		"properties": {
+			"VcpkgInstalledVCTargets" : "true",
+			"DisableInstalledVCTargetsUse" : "true"
+		}
+	},
+	"install": [
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/6d5f5c0638b80748cbd5b87a21852dcbde9e18418ec53e5d53c2fbd28d0e6b03/payload.vsix"
+			],
+			"sha256": "6d5f5c0638b80748cbd5b87a21852dcbde9e18418ec53e5d53c2fbd28d0e6b03",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=cs-CZ/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/3f5b60913c2734488ac7865190e00a0d1a039e5e607d98cb91ccbe8dd73ba664/payload.vsix"
+			],
+			"sha256": "3f5b60913c2734488ac7865190e00a0d1a039e5e607d98cb91ccbe8dd73ba664",
+			"lang": "cs-CZ",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=de-DE/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f28dd4303c725d643b67a7281f4896d282588b0a02ad0478f7c66fc94b2c2a60/payload.vsix"
+			],
+			"sha256": "f28dd4303c725d643b67a7281f4896d282588b0a02ad0478f7c66fc94b2c2a60",
+			"lang": "de-DE",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=en-US/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/dd04c0ac51bbe186b0c3089a895277ac6e583d35947153f119992b276044110e/payload.vsix"
+			],
+			"sha256": "dd04c0ac51bbe186b0c3089a895277ac6e583d35947153f119992b276044110e",
+			"lang": "en-US",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=es-ES/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/5f76200bee344972a90474fc9c546ba837e46ba0b3fe84577005acc0431849ad/payload.vsix"
+			],
+			"sha256": "5f76200bee344972a90474fc9c546ba837e46ba0b3fe84577005acc0431849ad",
+			"lang": "es-ES",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=fr-FR/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/69810b21b9016f5455034255b70342a301b143819574754fe1a7cb69df99c1fd/payload.vsix"
+			],
+			"sha256": "69810b21b9016f5455034255b70342a301b143819574754fe1a7cb69df99c1fd",
+			"lang": "fr-FR",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=it-IT/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/7ec697c9b838c3083a4c07e66d72dafaad10f9e14ed4d32a8e65fcdef1868c78/payload.vsix"
+			],
+			"sha256": "7ec697c9b838c3083a4c07e66d72dafaad10f9e14ed4d32a8e65fcdef1868c78",
+			"lang": "it-IT",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ja-JP/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/4df89bec0c2003a66bafd695ae338fc53424ff0ceb9ec948cd161a3111d61aa4/payload.vsix"
+			],
+			"sha256": "4df89bec0c2003a66bafd695ae338fc53424ff0ceb9ec948cd161a3111d61aa4",
+			"lang": "ja-JP",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ko-KR/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f41018ce193605929fc1a90af6e464ec6dcae2128fb3a5cd928d4ec305f6b516/payload.vsix"
+			],
+			"sha256": "f41018ce193605929fc1a90af6e464ec6dcae2128fb3a5cd928d4ec305f6b516",
+			"lang": "ko-KR",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=pl-PL/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/bd6343fe2e38434d8a1f3d75f712a0ad0966e7331c04f3d84e61799e6f7e121a/payload.vsix"
+			],
+			"sha256": "bd6343fe2e38434d8a1f3d75f712a0ad0966e7331c04f3d84e61799e6f7e121a",
+			"lang": "pl-PL",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=pt-BR/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/15b9da8cf7a2e01ed3ce70118182f53728d6d44f660202a85ffafc1b0ccbf1d6/payload.vsix"
+			],
+			"sha256": "15b9da8cf7a2e01ed3ce70118182f53728d6d44f660202a85ffafc1b0ccbf1d6",
+			"lang": "pt-BR",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=ru-RU/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/4202d7bb7a6c26594e271fea0a720e1efcfea1cfb7868384d04dce4205309a13/payload.vsix"
+			],
+			"sha256": "4202d7bb7a6c26594e271fea0a720e1efcfea1cfb7868384d04dce4205309a13",
+			"lang": "ru-RU",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=tr-TR/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/f2f13c0497f89d1a7f6f91e4412805a1a63bb9d1ef23af6c3b17fec54368a730/payload.vsix"
+			],
+			"sha256": "f2f13c0497f89d1a7f6f91e4412805a1a63bb9d1ef23af6c3b17fec54368a730",
+			"lang": "tr-TR",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=zh-CN/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/2b5bede7848422caec5787b4eccf9e5b382b5d7aa55ce24f22c73295cd942497/payload.vsix"
+			],
+			"sha256": "2b5bede7848422caec5787b4eccf9e5b382b5d7aa55ce24f22c73295cd942497",
+			"lang": "zh-CN",
+			"strip": 5
+		},
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base,version=17.0.0,productArch=neutral,language=zh-TW/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/15c92343-c6fc-4a1e-8f6e-c01d5eafdc04/32f042164bc0f1a6546e1194a731b4dcf83152bbf5bb18a1565e5c9b02393714/payload.vsix"
+			],
+			"sha256": "32f042164bc0f1a6546e1194a731b4dcf83152bbf5bb18a1565e5c9b02393714",
+			"lang": "zh-TW",
+			"strip": 5
+		}
+	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json
@@ -1,33 +1,33 @@
 {
-    "info": {
-        "id": "microsoft.visualstudio.vc.msbuild.v170.base.uwp",
-        "version": "17.0.0",
-        "description": "MSBuild support for vc projects (generated from VS install)",
-        "summary": "MSBuild support for vc projects (generated from VS install)"
-    },
-    "contacts": {
-        "Olga Arkhipova": {
-            "email": "olgaark@microsoft.com",
-            "role": "publisher"
-        }
-    },
-    "requires": {
-        "microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
-    },
-    "exports": {
-        "environment": {
-            "ApplicationTypeDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store",
-            "ApplicationTypeRevisionDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.base.uwp,version=17.0.0,productArch=neutral/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/1772f2ff-8ade-425c-a34a-7fad616734ec/578111b59b740eb60e224b82d799fd83238b49c44a905c6852c9cd0f1501e531/payload.vsix"
-            ],
-            "sha256": "578111b59b740eb60e224b82d799fd83238b49c44a905c6852c9cd0f1501e531",
-            "strip": 1
-        }
-    ]
+	"info": {
+		"id": "microsoft.visualstudio.vc.msbuild.v170.base.uwp",
+		"version": "17.0.0",
+		"description": "MSBuild support for vc projects (generated from VS install)",
+		"summary": "MSBuild support for vc projects (generated from VS install)"
+	}, 
+	"contacts": {
+		"Olga Arkhipova": {
+			"email": "olgaark@microsoft.com",
+			"role": "publisher"
+		}
+	},
+	"requires": {
+		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
+	},
+	"exports": {
+		"locations": {
+			"ApplicationTypeDirectory" : ".",
+			"ApplicationTypeRevisionDirectory" : ".\\10.0"
+		}
+	},
+	"install": [
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.base.uwp,version=17.0.0,productArch=neutral/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/1772f2ff-8ade-425c-a34a-7fad616734ec/578111b59b740eb60e224b82d799fd83238b49c44a905c6852c9cd0f1501e531/payload.vsix"
+			],
+			"sha256": "578111b59b740eb60e224b82d799fd83238b49c44a905c6852c9cd0f1501e531",
+			"strip": 7
+		}
+	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json
@@ -1,32 +1,32 @@
 {
-    "info": {
-        "id": "microsoft.visualstudio.vc.msbuild.v170.x64",
-        "version": "17.0.0",
-        "description": "MSBuild support for vc projects (generated from VS install)",
-        "summary": "MSBuild support for vc projects (generated from VS install)"
-    },
-    "contacts": {
-        "Olga Arkhipova": {
-            "email": "olgaark@microsoft.com",
-            "role": "publisher"
-        }
-    },
-    "requires": {
-        "microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
-    },
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\x64"
-        }
-    },
-    "install": [
-        {
-            "unzip": [
-                "vsix:///microsoft.visualstudio.vc.msbuild.v170.x64,version=17.0.0,productArch=neutral/payload.vsix",
-                "https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/ec7b9b1d2fd1586490fa4cf3baf77c753eb7e3356c930ff2521388e4ac5542aa/payload.vsix"
-            ],
-            "sha256": "ec7b9b1d2fd1586490fa4cf3baf77c753eb7e3356c930ff2521388e4ac5542aa",
-            "strip": 1
-        }
-    ]
+	"info": {
+		"id": "microsoft.visualstudio.vc.msbuild.v170.x64",
+		"version": "17.0.0",
+		"description": "MSBuild support for vc projects (generated from VS install)",
+		"summary": "MSBuild support for vc projects (generated from VS install)"
+	}, 
+	"contacts": {
+		"Olga Arkhipova": {
+			"email": "olgaark@microsoft.com",
+			"role": "publisher"
+		}
+	},
+	"requires": {
+		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
+	},
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : "."
+		}
+	},
+	"install": [
+		{
+			"unzip": [
+				"vsix:///microsoft.visualstudio.vc.msbuild.v170.x64,version=17.0.0,productArch=neutral/payload.vsix",
+				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/ec7b9b1d2fd1586490fa4cf3baf77c753eb7e3356c930ff2521388e4ac5542aa/payload.vsix"
+			],
+			"sha256": "ec7b9b1d2fd1586490fa4cf3baf77c753eb7e3356c930ff2521388e4ac5542aa",
+			"strip": 7
+		}
+	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json
@@ -14,12 +14,12 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base.uwp": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\x64",
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\x64\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : ".",
+			"ToolsetDirectory" : ".\\PlatformToolsets\\v143"
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -27,7 +27,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/f935720873c536a3da48046d06325b236da2e151dea24f5a92af47379e64b65a/payload.vsix"
 			],
 			"sha256": "f935720873c536a3da48046d06325b236da2e151dea24f5a92af47379e64b65a",
-			"strip": 1
+			"strip": 10
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.x64": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\x64\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"ToolsetDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/15e66f896b691ac3d936fa8a4c335e0ae814a89fa78742cb2caddc02789f8df4/payload.vsix"
 			],
 			"sha256": "15e66f896b691ac3d936fa8a4c335e0ae814a89fa78742cb2caddc02789f8df4",
-			"strip": 1
+			"strip": 9
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\Win32"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/3d1119d105e03c47cfcd5d1ae7566e6ae4f9808f557972860ef3eb8928f5964e/payload.vsix"
 			],
 			"sha256": "3d1119d105e03c47cfcd5d1ae7566e6ae4f9808f557972860ef3eb8928f5964e",
-			"strip": 1
+			"strip": 7
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json
@@ -14,12 +14,12 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.base.uwp": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "PlatformDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\Win32",
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Application Type\\Windows Store\\10.0\\Platforms\\Win32\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"PlatformDirectory" : ".",
+			"ToolsetDirectory" : ".\\PlatformToolsets\\v143"
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -27,7 +27,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/c8d6c75b108bd6ce5572607c0537817ac2a215a08c8e6659aaac51a05e2bac54/payload.vsix"
 			],
 			"sha256": "c8d6c75b108bd6ce5572607c0537817ac2a215a08c8e6659aaac51a05e2bac54",
-			"strip": 1
+			"strip": 10
 		}
 	]
 }

--- a/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json
+++ b/tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json
@@ -14,11 +14,11 @@
 	"requires": {
 		"microsoft.visualstudio.vc.msbuild.v170.x86": "17.0.0"
 	},
-    "exports": {
-        "environment": {
-            "ToolsetDirectory": ".\\Contents\\Msbuild\\Microsoft\\VC\\v170\\Platforms\\Win32\\PlatformToolsets\\v143"
-        }
-    },
+	"exports": {
+		"locations": {
+			"ToolsetDirectory" : "."
+		}
+	},
 	"install": [
 		{
 			"unzip": [
@@ -26,7 +26,7 @@
 				"https://download.visualstudio.microsoft.com/download/pr/f84477aa-ef95-484f-a213-840989c199bc/2a059cfe5c54e12930fafa8283b870e80b27dd014eb2be28d23a5af1585e63d1/payload.vsix"
 			],
 			"sha256": "2a059cfe5c54e12930fafa8283b870e80b27dd014eb2be28d23a5af1585e63d1",
-			"strip": 1
+			"strip": 9
 		}
 	]
 }


### PR DESCRIPTION
Changing MSVC and Msbuild artifacts to use locations and properties to make .props generation work.