### PR TITLE
Msbuild properties changes to enable msbuild demo

### DIFF
--- a/crts/microsoft/desktop/arm/arm-14.28.29915.json
+++ b/crts/microsoft/desktop/arm/arm-14.28.29915.json
@@ -1,4 +1,10 @@
 {
+  "id": "crts/microsoft/desktop/arm",
+  "version": "14.28.29915",
+  "summary": "MSVC standard library libraries (desktop / kernel32)",
+  "options": [
+    "dependencyOnly"
+  ],
   "contacts": {
     "Mark Levine": {
       "email": "markle@microsoft.com",
@@ -12,7 +18,7 @@
       "lib": "."
     },
     "msbuild-properties": {
-      "VC_LibraryPath_VC_ARM_Desktop": "."
+      "VC_LibraryPath_VC_ARM_Desktop": "{root}"
     }
   },
   "requires": {
@@ -27,11 +33,5 @@
       "sha256": "6e893932951d3a970fc8c9ab25cbd6ad5a30018e841951966ed7fd1f0cc5f04e",
       "strip": 7
     }
-  ],
-  "id": "crts/microsoft/desktop/arm",
-  "version": "14.28.29915",
-  "summary": "MSVC standard library libraries (desktop / kernel32)",
-  "options": [
-    "dependencyOnly"
   ]
 }

--- a/crts/microsoft/desktop/x64/x64-14.29.30037.json
+++ b/crts/microsoft/desktop/x64/x64-14.29.30037.json
@@ -14,7 +14,8 @@
           "LIB": "."
         },
         "msbuild-properties": {
-          "VC_LibraryPath_VC_x64_Desktop": "{root}"
+          "VC_LibraryPath_VC_x64_Desktop": "{root}",
+          "VC_LibraryPath_VC_x64": "{root};$(VC_LibraryPath_VC_x64)"
         }
       }
     }

--- a/crts/microsoft/desktop/x86/x86-14.29.30037.json
+++ b/crts/microsoft/desktop/x86/x86-14.29.30037.json
@@ -18,7 +18,8 @@
           "LIBPATH": "."
         },
         "msbuild-properties": {
-          "VC_LibraryPath_VC_x86_Desktop": "{root}"
+          "VC_LibraryPath_VC_x86_Desktop": "{root}",
+          "VC_LibraryPath_VC_x86": "{root};$(VC_LibraryPath_VC_x86)"
         }
       }
     }

--- a/crts/microsoft/headers/headers-14.28.29912.json
+++ b/crts/microsoft/headers/headers-14.28.29912.json
@@ -12,7 +12,8 @@
       "include": "."
     },
     "msbuild-properties": {
-      "VC_VC_IncludePath": "{root}"
+      "VC_VC_IncludePath": "{root}",
+      "VCManifestDir": "{root}\\Manifest\\"
     }
   },
   "install": [

--- a/crts/microsoft/headers/headers-14.29.30037.json
+++ b/crts/microsoft/headers/headers-14.29.30037.json
@@ -17,7 +17,8 @@
           "INCLUDE": "."
         },
         "msbuild-properties": {
-          "VC_VC_IncludePath": "{root}"
+          "VC_VC_IncludePath": "{root}",
+          "VCManifestDir": "{root}\\Manifest\\"
         }
       }
     }

--- a/crts/microsoft/onecore/x64/x64-14.29.30037.json
+++ b/crts/microsoft/onecore/x64/x64-14.29.30037.json
@@ -12,7 +12,8 @@
       "LIB": "."
     },
     "msbuild-properties": {
-      "VC_LibraryPath_VC_x64_OneCore": "{root}"
+      "VC_LibraryPath_VC_x64_OneCore": "{root}",
+      "VC_LibraryPath_VC_x64": "$(VC_LibraryPath_VC_x64);{root}"
     }
   },
   "requires": {

--- a/crts/microsoft/onecore/x86/x86-14.29.30037.json
+++ b/crts/microsoft/onecore/x86/x86-14.29.30037.json
@@ -15,7 +15,8 @@
       "LIB": "."
     },
     "msbuild-properties": {
-      "VC_LibraryPath_VC_x86_Onecore": "{root}"
+      "VC_LibraryPath_VC_x86_Onecore": "{root}",
+      "VC_LibraryPath_VC_x86": "$(VC_LibraryPath_VC_x86);{root}"
     }
   },
   "demands": {

--- a/index.yaml
+++ b/index.yaml
@@ -1,110 +1,110 @@
 # MANIFEST-INDEX
 items:
   [
-    compilers/arm/gcc/gcc-2020.10.0.json,    crts/microsoft/asan/x64/x64-14.29.30037.json,    crts/microsoft/asan/x64/x64-14.28.29915.json,    crts/microsoft/asan/asan-14.29.30037.json,    crts/microsoft/asan/asan-14.28.29915.json,    crts/microsoft/asan/x86/x86-14.28.29915.json,    crts/microsoft/asan/x86/x86-14.29.30037.json,    crts/microsoft/desktop/arm/arm-14.28.29915.json,    crts/microsoft/desktop/arm/arm-14.29.30037.json,    crts/microsoft/desktop/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop/desktop-14.28.29915.json,    crts/microsoft/desktop/x64/x64-14.28.29915.json,    crts/microsoft/desktop/desktop-14.29.30037.json,    crts/microsoft/desktop/x64/x64-14.29.30037.json,    crts/microsoft/desktop/x86/x86-14.29.30037.json,    crts/microsoft/desktop/x86/x86-14.28.29915.json,    crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json,    crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.28.29915.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json,    crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json,    crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json,    crts/microsoft/headers/headers-14.29.30037.json,    crts/microsoft/headers/headers-14.28.29912.json,    crts/microsoft/onecore/arm/arm-14.29.30037.json,    crts/microsoft/onecore/arm/arm-14.28.29915.json,    crts/microsoft/onecore/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore/onecore-14.29.30037.json,    crts/microsoft/onecore/onecore-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.29.30037.json,    crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json,    crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json,    crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json,    crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json,    tools/arduino/arduino-ide-1.18.15.json,    tools/arduino/arduino-cli-0.18.3.json,    tools/compuphase/termite-3.4.0.json,    tools/kitware/cmake-3.20.1.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json,    tools/ninja-build/ninja-1.10.2.json,    tools/microsoft/openocd-0.11.0.json,    tools/microsoft/openocd-0.11.0-ms1.json,    tools/microsoft/msbuild/vc/v143_17.0.0.json,    tools/microsoft/msbuild/vc/UWP_17.0.0.json,    tools/microsoft/msbuild/vc/Desktop_v143_17.0.0.json,    tools/raspberrypi/pico-sdk-1.3.0.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json,    sdks/microsoft/atl/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl/arm/arm-14.28.29914.json,    sdks/microsoft/atl/arm/arm-14.29.30037.json,    sdks/microsoft/atl/atl-14.28.29914.json,    sdks/microsoft/atl/atl-14.29.30037.json,    sdks/microsoft/atl/x64/x64-14.28.29914.json,    sdks/microsoft/atl/x64/x64-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.28.29914.json,    sdks/microsoft/atl-headers/atl-headers-14.28.29914.json,    sdks/microsoft/atl-headers/atl-headers-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl-spectre/atl-spectre-14.29.30037.json,    sdks/microsoft/atl-spectre/atl-spectre-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json,    sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json,    sdks/microsoft/mfc-headers/mfc-headers-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/windows/windows-10.0.17763.json,    sdks/microsoft/windows/windows-10.0.18362.json,    sdks/microsoft/windows/windows-10.0.19041.json,    sdks/microsoft/windows/windows-10.0.22621.json,    sdks/microsoft/windows/windows.arm-10.0.22621.json,    sdks/microsoft/windows/windows.arm-10.0.17763.json,    sdks/microsoft/windows/windows.arm64-10.0.17763.json,    sdks/microsoft/windows/windows.arm64-10.0.18362.json,    sdks/microsoft/windows/windows.arm64-10.0.19041.json,    sdks/microsoft/windows/windows.x64-10.0.17763.json,    sdks/microsoft/windows/windows.arm64-10.0.22621.json,    microsoft/diasdk/diasdk-14.28.29915.json,    microsoft/diasdk/diasdk-14.29.30037.json,    sdks/microsoft/windows/windows.x64-10.0.18362.json,    microsoft/msvc/msvc-14.29.30037.json,    microsoft/msvc/msvc-14.28.29915.json,    sdks/microsoft/windows/windows.x64-10.0.19041.json,    sdks/microsoft/windows/windows.x64-10.0.22621.json,    sdks/microsoft/windows/windows.x86-10.0.17763.json,    microsoft/msvc/x64_arm/x64_arm-14.29.30037.json,    microsoft/msvc/x64_arm/x64_arm-14.28.29915.json,    sdks/microsoft/windows/windows.x86-10.0.18362.json,    microsoft/msvc/x64_x64/x64_x64-14.29.30037.json,    microsoft/msvc/x64_x64/x64_x64-14.28.29915.json,    sdks/microsoft/windows/windows.x86-10.0.19041.json,    microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json,    microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json,    sdks/microsoft/windows/windows.x86-10.0.22621.json,    microsoft/msvc/x64_x86/x64_x86-14.29.30037.json,    microsoft/msvc/x64_x86/x64_x86-14.28.29915.json,    sdks/microsoft/windows/windows.arm-10.0.19041.json,    microsoft/msvc/x86_arm/x86_arm-14.29.30037.json,    microsoft/msvc/x86_arm/x86_arm-14.28.29915.json,    sdks/microsoft/windows/windows.arm-10.0.18362.json,    microsoft/msvc/x86_x86/x86_x86-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.29.30037.json,    microsoft/msvc/x86_x64/x86_x64-14.28.29915.json,    microsoft/msvc/x86_x64/x86_x64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json,    microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json
+    compilers/arm/gcc/gcc-2020.10.0.json,    crts/microsoft/asan/asan-14.29.30037.json,    crts/microsoft/asan/asan-14.28.29915.json,    crts/microsoft/asan/x64/x64-14.28.29915.json,    crts/microsoft/asan/x64/x64-14.29.30037.json,    crts/microsoft/asan/x86/x86-14.28.29915.json,    crts/microsoft/asan/x86/x86-14.29.30037.json,    crts/microsoft/desktop/arm/arm-14.28.29915.json,    crts/microsoft/desktop/arm/arm-14.29.30037.json,    crts/microsoft/desktop/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop/desktop-14.28.29915.json,    crts/microsoft/desktop/desktop-14.29.30037.json,    crts/microsoft/desktop/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop/x64/x64-14.29.30037.json,    crts/microsoft/desktop/x64/x64-14.28.29915.json,    crts/microsoft/desktop/x86/x86-14.28.29915.json,    crts/microsoft/desktop/x86/x86-14.29.30037.json,    crts/microsoft/desktop-spectre/arm/arm-14.28.29915.json,    crts/microsoft/desktop-spectre/arm/arm-14.29.30037.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/desktop-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.29.30037.json,    crts/microsoft/desktop-spectre/x64/x64-14.28.29915.json,    crts/microsoft/desktop-spectre/x64/x64-14.29.30037.json,    crts/microsoft/desktop-spectre/desktop-spectre-14.28.29915.json,    crts/microsoft/desktop-spectre/x86/x86-14.29.30037.json,    crts/microsoft/desktop-spectre/x86/x86-14.28.29915.json,    crts/microsoft/headers/headers-14.28.29912.json,    crts/microsoft/headers/headers-14.29.30037.json,    crts/microsoft/onecore-spectre/arm/arm-14.28.29915.json,    crts/microsoft/onecore-spectre/arm/arm-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore-spectre/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.28.29915.json,    crts/microsoft/onecore-spectre/onecore-spectre-14.29.30037.json,    crts/microsoft/onecore-spectre/x64/x64-14.29.30037.json,    crts/microsoft/onecore-spectre/x64/x64-14.28.29915.json,    crts/microsoft/onecore-spectre/x86/x86-14.29.30037.json,    crts/microsoft/onecore-spectre/x86/x86-14.28.29915.json,    crts/microsoft/onecore/arm/arm-14.28.29915.json,    crts/microsoft/onecore/arm/arm-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.29.30037.json,    crts/microsoft/onecore/onecore-14.29.30037.json,    crts/microsoft/onecore/arm64/arm64-14.28.29915.json,    crts/microsoft/onecore/onecore-14.28.29915.json,    crts/microsoft/onecore/x64/x64-14.29.30037.json,    crts/microsoft/onecore/x64/x64-14.28.29915.json,    crts/microsoft/onecore/x86/x86-14.29.30037.json,    crts/microsoft/onecore/x86/x86-14.28.29915.json,    tools/arduino/arduino-ide-1.18.15.json,    tools/arduino/arduino-cli-0.18.3.json,    tools/compuphase/termite-3.4.0.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64.v143.json,    tools/microsoft/openocd-0.11.0.json,    tools/kitware/cmake-3.20.1.json,    tools/microsoft/openocd-0.11.0-ms1.json,    tools/microsoft/msbuild/vc/UWP_17.0.0.json,    tools/raspberrypi/pico-sdk-1.3.0.json,    tools/microsoft/msbuild/vc/v143_17.0.0.json,    tools/microsoft/msbuild/vc/Desktop_v143_17.0.0.json,    tools/ninja-build/ninja-1.10.2.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.base.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.v143.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x64.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.uwp.json,    tools/microsoft/msbuild/vc/17.0/microsoft.visualstudio.vc.msbuild.v170.x86.v143.json,    sdks/microsoft/atl/arm/arm-14.28.29914.json,    sdks/microsoft/atl/arm/arm-14.29.30037.json,    sdks/microsoft/atl/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl/atl-14.28.29914.json,    sdks/microsoft/atl/atl-14.29.30037.json,    sdks/microsoft/atl/x64/x64-14.28.29914.json,    sdks/microsoft/atl/x64/x64-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.29.30037.json,    sdks/microsoft/atl/x86/x86-14.28.29914.json,    sdks/microsoft/atl-headers/atl-headers-14.29.30037.json,    sdks/microsoft/atl-headers/atl-headers-14.28.29914.json,    sdks/microsoft/atl-spectre/arm/arm-14.29.30037.json,    sdks/microsoft/atl-spectre/arm/arm-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.28.29914.json,    sdks/microsoft/atl-spectre/arm64/arm64-14.29.30037.json,    sdks/microsoft/atl-spectre/atl-spectre-14.28.29914.json,    sdks/microsoft/atl-spectre/atl-spectre-14.29.30037.json,    sdks/microsoft/atl-spectre/x86/x86-14.28.29914.json,    sdks/microsoft/atl-spectre/x86/x86-14.29.30037.json,    sdks/microsoft/atl-spectre/x64/x64-14.29.30037.json,    sdks/microsoft/atl-spectre/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json,    sdks/microsoft/mfc-headers/mfc-headers-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/mbcs-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/mbcs/x86/x86-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm/arm-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/arm64/arm64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x64/x64-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/unicode-14.29.30037.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.28.29914.json,    sdks/microsoft/mfc-spectre/unicode/x86/x86-14.29.30037.json,    sdks/microsoft/windows/windows-10.0.17763.json,    sdks/microsoft/windows/windows-10.0.22621.json,    sdks/microsoft/windows/windows-10.0.18362.json,    sdks/microsoft/windows/windows-10.0.19041.json,    sdks/microsoft/windows/windows.arm-10.0.17763.json,    sdks/microsoft/windows/windows.arm-10.0.22621.json,    sdks/microsoft/windows/windows.arm64-10.0.17763.json,    sdks/microsoft/windows/windows.arm64-10.0.18362.json,    sdks/microsoft/windows/windows.arm64-10.0.19041.json,    sdks/microsoft/windows/windows.arm64-10.0.22621.json,    sdks/microsoft/windows/windows.x64-10.0.18362.json,    sdks/microsoft/windows/windows.x64-10.0.17763.json,    sdks/microsoft/windows/windows.x64-10.0.19041.json,    microsoft/diasdk/diasdk-14.29.30037.json,    microsoft/diasdk/diasdk-14.28.29915.json,    sdks/microsoft/windows/windows.x64-10.0.22621.json,    sdks/microsoft/windows/windows.x86-10.0.17763.json,    microsoft/msvc/msvc-14.29.30037.json,    microsoft/msvc/msvc-14.28.29915.json,    sdks/microsoft/windows/windows.x86-10.0.18362.json,    sdks/microsoft/windows/windows.x86-10.0.19041.json,    microsoft/msvc/x64_arm/x64_arm-14.29.30037.json,    microsoft/msvc/x64_arm/x64_arm-14.28.29915.json,    sdks/microsoft/windows/windows.arm-10.0.18362.json,    sdks/microsoft/windows/windows.x86-10.0.22621.json,    microsoft/msvc/x64_x64/x64_x64-14.29.30037.json,    microsoft/msvc/x64_x64/x64_x64-14.28.29915.json,    sdks/microsoft/windows/windows.arm-10.0.19041.json,    microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json,    microsoft/msvc/x64_arm64/x64_arm64-14.28.29915.json,    microsoft/msvc/x64_x86/x64_x86-14.28.29915.json,    microsoft/msvc/x64_x86/x64_x86-14.29.30037.json,    microsoft/msvc/x86_arm/x86_arm-14.29.30037.json,    microsoft/msvc/x86_arm/x86_arm-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.28.29915.json,    microsoft/msvc/x86_x86/x86_x86-14.29.30037.json,    microsoft/msvc/x86_x64/x86_x64-14.28.29915.json,    microsoft/msvc/x86_x64/x86_x64-14.29.30037.json,    microsoft/msvc/x86_arm64/x86_arm64-14.28.29915.json,    microsoft/msvc/x86_arm64/x86_arm64-14.29.30037.json
   ]
 indexes:
   IdentityKey/id:
     keys:
       compilers/arm/gcc: [ 0 ]
-      crts/microsoft/asan: [ 3, 4 ]
-      crts/microsoft/asan/x64: [ 1, 2 ]
+      crts/microsoft/asan: [ 1, 2 ]
+      crts/microsoft/asan/x64: [ 3, 4 ]
       crts/microsoft/asan/x86: [ 5, 6 ]
-      crts/microsoft/desktop: [ 11, 13 ]
-      crts/microsoft/desktop-spectre: [ 20, 22 ]
+      crts/microsoft/desktop: [ 10, 11 ]
+      crts/microsoft/desktop-spectre: [ 21, 24 ]
       crts/microsoft/desktop-spectre/arm: [ 17, 18 ]
-      crts/microsoft/desktop-spectre/arm64: [ 19, 21 ]
-      crts/microsoft/desktop-spectre/x64: [ 23, 24 ]
+      crts/microsoft/desktop-spectre/arm64: [ 19, 20 ]
+      crts/microsoft/desktop-spectre/x64: [ 22, 23 ]
       crts/microsoft/desktop-spectre/x86: [ 25, 26 ]
       crts/microsoft/desktop/arm: [ 7, 8 ]
-      crts/microsoft/desktop/arm64: [ 9, 10 ]
-      crts/microsoft/desktop/x64: [ 12, 14 ]
+      crts/microsoft/desktop/arm64: [ 9, 12 ]
+      crts/microsoft/desktop/x64: [ 13, 14 ]
       crts/microsoft/desktop/x86: [ 15, 16 ]
       crts/microsoft/headers: [ 27, 28 ]
-      crts/microsoft/onecore: [ 33, 34 ]
-      crts/microsoft/onecore-spectre: [ 43, 44 ]
-      crts/microsoft/onecore-spectre/arm: [ 39, 40 ]
-      crts/microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      crts/microsoft/onecore-spectre/x64: [ 45, 46 ]
-      crts/microsoft/onecore-spectre/x86: [ 47, 48 ]
-      crts/microsoft/onecore/arm: [ 29, 30 ]
-      crts/microsoft/onecore/arm64: [ 31, 32 ]
-      crts/microsoft/onecore/x64: [ 35, 36 ]
-      crts/microsoft/onecore/x86: [ 37, 38 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm: [ 54 ]
+      crts/microsoft/onecore: [ 42, 44 ]
+      crts/microsoft/onecore-spectre: [ 33, 34 ]
+      crts/microsoft/onecore-spectre/arm: [ 29, 30 ]
+      crts/microsoft/onecore-spectre/arm64: [ 31, 32 ]
+      crts/microsoft/onecore-spectre/x64: [ 35, 36 ]
+      crts/microsoft/onecore-spectre/x86: [ 37, 38 ]
+      crts/microsoft/onecore/arm: [ 39, 40 ]
+      crts/microsoft/onecore/arm64: [ 41, 43 ]
+      crts/microsoft/onecore/x64: [ 45, 46 ]
+      crts/microsoft/onecore/x86: [ 47, 48 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm: [ 52 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 55 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.v143: [ 53 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64: [ 56 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 58 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 57 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 59 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 54 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 57 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 67 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 68 ]
-      microsoft.visualstudio.vc.msbuild.v170.base: [ 69 ]
-      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
+      microsoft.visualstudio.vc.msbuild.v170.base: [ 70 ]
+      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 69 ]
       microsoft.visualstudio.vc.msbuild.v170.x64: [ 71 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86: [ 74 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 74 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 72 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86: [ 73 ]
       microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
       microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
-      microsoft/diasdk: [ 152, 153 ]
-      microsoft/msvc: [ 155, 156 ]
-      microsoft/msvc/x64_arm: [ 160, 161 ]
-      microsoft/msvc/x64_arm64: [ 166, 167 ]
-      microsoft/msvc/x64_x64: [ 163, 164 ]
-      microsoft/msvc/x64_x86: [ 169, 170 ]
-      microsoft/msvc/x86_arm: [ 172, 173 ]
+      microsoft/diasdk: [ 154, 155 ]
+      microsoft/msvc: [ 158, 159 ]
+      microsoft/msvc/x64_arm: [ 162, 163 ]
+      microsoft/msvc/x64_arm64: [ 169, 170 ]
+      microsoft/msvc/x64_x64: [ 166, 167 ]
+      microsoft/msvc/x64_x86: [ 171, 172 ]
+      microsoft/msvc/x86_arm: [ 173, 174 ]
       microsoft/msvc/x86_arm64: [ 179, 180 ]
       microsoft/msvc/x86_x64: [ 177, 178 ]
       microsoft/msvc/x86_x86: [ 175, 176 ]
-      raspberrypi/pico-sdk: [ 66 ]
+      raspberrypi/pico-sdk: [ 63 ]
       sdks/microsoft/atl: [ 81, 82 ]
       sdks/microsoft/atl-headers: [ 87, 88 ]
-      sdks/microsoft/atl-spectre: [ 92, 93 ]
+      sdks/microsoft/atl-spectre: [ 93, 94 ]
       sdks/microsoft/atl-spectre/arm: [ 89, 90 ]
-      sdks/microsoft/atl-spectre/arm64: [ 91, 94 ]
-      sdks/microsoft/atl-spectre/x64: [ 95, 96 ]
-      sdks/microsoft/atl-spectre/x86: [ 97, 98 ]
-      sdks/microsoft/atl/arm: [ 79, 80 ]
-      sdks/microsoft/atl/arm64: [ 77, 78 ]
+      sdks/microsoft/atl-spectre/arm64: [ 91, 92 ]
+      sdks/microsoft/atl-spectre/x64: [ 97, 98 ]
+      sdks/microsoft/atl-spectre/x86: [ 95, 96 ]
+      sdks/microsoft/atl/arm: [ 77, 78 ]
+      sdks/microsoft/atl/arm64: [ 79, 80 ]
       sdks/microsoft/atl/x64: [ 83, 84 ]
       sdks/microsoft/atl/x86: [ 85, 86 ]
       sdks/microsoft/mfc-headers: [ 119, 120 ]
-      sdks/microsoft/mfc-spectre/mbcs: [ 121, 128 ]
-      sdks/microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
-      sdks/microsoft/mfc-spectre/mbcs/arm64: [ 124, 126 ]
-      sdks/microsoft/mfc-spectre/mbcs/x64: [ 125, 127 ]
+      sdks/microsoft/mfc-spectre/mbcs: [ 124, 126 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm: [ 121, 122 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm64: [ 123, 125 ]
+      sdks/microsoft/mfc-spectre/mbcs/x64: [ 127, 128 ]
       sdks/microsoft/mfc-spectre/mbcs/x86: [ 129, 130 ]
-      sdks/microsoft/mfc-spectre/unicode: [ 134, 136 ]
+      sdks/microsoft/mfc-spectre/unicode: [ 135, 138 ]
       sdks/microsoft/mfc-spectre/unicode/arm: [ 131, 132 ]
-      sdks/microsoft/mfc-spectre/unicode/arm64: [ 133, 135 ]
-      sdks/microsoft/mfc-spectre/unicode/x64: [ 137, 138 ]
+      sdks/microsoft/mfc-spectre/unicode/arm64: [ 133, 134 ]
+      sdks/microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
       sdks/microsoft/mfc-spectre/unicode/x86: [ 139, 140 ]
-      sdks/microsoft/mfc/mbcs: [ 101, 104 ]
+      sdks/microsoft/mfc/mbcs: [ 102, 106 ]
       sdks/microsoft/mfc/mbcs/arm: [ 99, 100 ]
-      sdks/microsoft/mfc/mbcs/arm64: [ 102, 103 ]
-      sdks/microsoft/mfc/mbcs/x64: [ 105, 106 ]
+      sdks/microsoft/mfc/mbcs/arm64: [ 101, 103 ]
+      sdks/microsoft/mfc/mbcs/x64: [ 104, 105 ]
       sdks/microsoft/mfc/mbcs/x86: [ 107, 108 ]
-      sdks/microsoft/mfc/unicode: [ 112, 114 ]
-      sdks/microsoft/mfc/unicode/arm: [ 109, 110 ]
-      sdks/microsoft/mfc/unicode/arm64: [ 111, 113 ]
-      sdks/microsoft/mfc/unicode/x64: [ 115, 116 ]
+      sdks/microsoft/mfc/unicode: [ 112, 116 ]
+      sdks/microsoft/mfc/unicode/arm: [ 111, 113 ]
+      sdks/microsoft/mfc/unicode/arm64: [ 109, 110 ]
+      sdks/microsoft/mfc/unicode/x64: [ 114, 115 ]
       sdks/microsoft/mfc/unicode/x86: [ 117, 118 ]
       sdks/microsoft/windows: [ 141, 142, 143, 144 ]
-      sdks/microsoft/windows/windows.arm: [ 145, 146, 171, 174 ]
-      sdks/microsoft/windows/windows.arm64: [ 147, 148, 149, 151 ]
-      sdks/microsoft/windows/windows.x64: [ 150, 154, 157, 158 ]
-      sdks/microsoft/windows/windows.x86: [ 159, 162, 165, 168 ]
+      sdks/microsoft/windows/windows.arm: [ 145, 146, 164, 168 ]
+      sdks/microsoft/windows/windows.arm64: [ 147, 148, 149, 150 ]
+      sdks/microsoft/windows/windows.x64: [ 151, 152, 153, 156 ]
+      sdks/microsoft/windows/windows.x86: [ 157, 160, 161, 165 ]
       tools/arduino/arduino-cli: [ 50 ]
       tools/arduino/arduino-ide: [ 49 ]
       tools/compuphase/termite: [ 51 ]
-      tools/kitware/cmake: [ 52 ]
+      tools/kitware/cmake: [ 60 ]
       tools/microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      tools/microsoft/msbuild/vc/uwp: [ 64 ]
-      tools/microsoft/msbuild/vc/v143: [ 63 ]
-      tools/microsoft/openocd: [ 61, 62 ]
-      tools/ninja-build/ninja: [ 60 ]
+      tools/microsoft/msbuild/vc/uwp: [ 62 ]
+      tools/microsoft/msbuild/vc/v143: [ 64 ]
+      tools/microsoft/openocd: [ 59, 61 ]
+      tools/ninja-build/ninja: [ 66 ]
     words:
       Desktop: [ 65 ]
       Desktop/v143: [ 65 ]
@@ -115,21 +115,21 @@ indexes:
       arduino/arduino-cli: [ 50 ]
       arduino/arduino-ide: [ 49 ]
       arm:
-        [0,7,8,17,18,29,30,39,40,53,54,55,79,80,89,90,99,100,109,110,122,123,131,132,145,146,171,          174
+        [0,7,8,17,18,29,30,39,40,52,53,55,77,78,89,90,99,100,111,113,121,122,131,132,145,146,164,          168
         ]
       arm.uwp: [ 55 ]
       arm.v143: [ 53 ]
       arm/gcc: [ 0 ]
       arm64:
-        [9,10,19,21,31,32,41,42,56,57,58,77,78,91,94,102,103,111,113,124,126,133,135,147,148,149,          151
+        [9,12,19,20,31,32,41,43,54,56,58,79,80,91,92,101,103,109,110,123,125,133,134,147,148,149,          150
         ]
-      arm64.uwp: [ 58 ]
-      arm64.v143: [ 57 ]
-      arm64ec: [ 59, 67, 68 ]
+      arm64.uwp: [ 54 ]
+      arm64.v143: [ 58 ]
+      arm64ec: [ 57, 67, 68 ]
       arm64ec.uwp: [ 67 ]
       arm64ec.v143: [ 68 ]
       asan: [ 1, 2, 3, 4, 5, 6 ]
-      asan/x64: [ 1, 2 ]
+      asan/x64: [ 3, 4 ]
       asan/x86: [ 5, 6 ]
       atl:
         [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,          98
@@ -137,19 +137,19 @@ indexes:
       atl-headers: [ 87, 88 ]
       atl-spectre: [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98 ]
       atl-spectre/arm: [ 89, 90 ]
-      atl-spectre/arm64: [ 91, 94 ]
-      atl-spectre/x64: [ 95, 96 ]
-      atl-spectre/x86: [ 97, 98 ]
-      atl/arm: [ 79, 80 ]
-      atl/arm64: [ 77, 78 ]
+      atl-spectre/arm64: [ 91, 92 ]
+      atl-spectre/x64: [ 97, 98 ]
+      atl-spectre/x86: [ 95, 96 ]
+      atl/arm: [ 77, 78 ]
+      atl/arm64: [ 79, 80 ]
       atl/x64: [ 83, 84 ]
       atl/x86: [ 85, 86 ]
       base: [ 69, 70 ]
-      base.uwp: [ 70 ]
-      build: [ 60 ]
-      build/ninja: [ 60 ]
+      base.uwp: [ 69 ]
+      build: [ 66 ]
+      build/ninja: [ 66 ]
       cli: [ 50 ]
-      cmake: [ 52 ]
+      cmake: [ 60 ]
       compilers: [ 0 ]
       compilers/arm: [ 0 ]
       compilers/arm/gcc: [ 0 ]
@@ -162,57 +162,57 @@ indexes:
         [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       crts/microsoft/asan: [ 1, 2, 3, 4, 5, 6 ]
-      crts/microsoft/asan/x64: [ 1, 2 ]
+      crts/microsoft/asan/x64: [ 3, 4 ]
       crts/microsoft/asan/x86: [ 5, 6 ]
       crts/microsoft/desktop:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
       crts/microsoft/desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
       crts/microsoft/desktop-spectre/arm: [ 17, 18 ]
-      crts/microsoft/desktop-spectre/arm64: [ 19, 21 ]
-      crts/microsoft/desktop-spectre/x64: [ 23, 24 ]
+      crts/microsoft/desktop-spectre/arm64: [ 19, 20 ]
+      crts/microsoft/desktop-spectre/x64: [ 22, 23 ]
       crts/microsoft/desktop-spectre/x86: [ 25, 26 ]
       crts/microsoft/desktop/arm: [ 7, 8 ]
-      crts/microsoft/desktop/arm64: [ 9, 10 ]
-      crts/microsoft/desktop/x64: [ 12, 14 ]
+      crts/microsoft/desktop/arm64: [ 9, 12 ]
+      crts/microsoft/desktop/x64: [ 13, 14 ]
       crts/microsoft/desktop/x86: [ 15, 16 ]
       crts/microsoft/headers: [ 27, 28 ]
       crts/microsoft/onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
-      crts/microsoft/onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
-      crts/microsoft/onecore-spectre/arm: [ 39, 40 ]
-      crts/microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      crts/microsoft/onecore-spectre/x64: [ 45, 46 ]
-      crts/microsoft/onecore-spectre/x86: [ 47, 48 ]
-      crts/microsoft/onecore/arm: [ 29, 30 ]
-      crts/microsoft/onecore/arm64: [ 31, 32 ]
-      crts/microsoft/onecore/x64: [ 35, 36 ]
-      crts/microsoft/onecore/x86: [ 37, 38 ]
+      crts/microsoft/onecore-spectre: [ 29, 30, 31, 32, 33, 34, 35, 36, 37, 38 ]
+      crts/microsoft/onecore-spectre/arm: [ 29, 30 ]
+      crts/microsoft/onecore-spectre/arm64: [ 31, 32 ]
+      crts/microsoft/onecore-spectre/x64: [ 35, 36 ]
+      crts/microsoft/onecore-spectre/x86: [ 37, 38 ]
+      crts/microsoft/onecore/arm: [ 39, 40 ]
+      crts/microsoft/onecore/arm64: [ 41, 43 ]
+      crts/microsoft/onecore/x64: [ 45, 46 ]
+      crts/microsoft/onecore/x86: [ 47, 48 ]
       desktop:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
       desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
       desktop-spectre/arm: [ 17, 18 ]
-      desktop-spectre/arm64: [ 19, 21 ]
-      desktop-spectre/x64: [ 23, 24 ]
+      desktop-spectre/arm64: [ 19, 20 ]
+      desktop-spectre/x64: [ 22, 23 ]
       desktop-spectre/x86: [ 25, 26 ]
       desktop/arm: [ 7, 8 ]
-      desktop/arm64: [ 9, 10 ]
-      desktop/x64: [ 12, 14 ]
+      desktop/arm64: [ 9, 12 ]
+      desktop/x64: [ 13, 14 ]
       desktop/x86: [ 15, 16 ]
-      diasdk: [ 152, 153 ]
+      diasdk: [ 154, 155 ]
       gcc: [ 0 ]
       headers: [ 27, 28, 87, 88, 119, 120 ]
       ide: [ 49 ]
-      kitware: [ 52 ]
-      kitware/cmake: [ 52 ]
+      kitware: [ 60 ]
+      kitware/cmake: [ 60 ]
       mbcs:
         [99,100,101,102,103,104,105,106,107,108,121,122,123,124,125,126,127,128,129,          130
         ]
-      mbcs/arm: [ 99, 100, 122, 123 ]
-      mbcs/arm64: [ 102, 103, 124, 126 ]
-      mbcs/x64: [ 105, 106, 125, 127 ]
+      mbcs/arm: [ 99, 100, 121, 122 ]
+      mbcs/arm64: [ 101, 103, 123, 125 ]
+      mbcs/x64: [ 104, 105, 127, 128 ]
       mbcs/x86: [ 107, 108, 129, 130 ]
       mfc:
         [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
@@ -224,63 +224,63 @@ indexes:
       mfc-spectre/mbcs:
         [121,122,123,124,125,126,127,128,129,          130
         ]
-      mfc-spectre/mbcs/arm: [ 122, 123 ]
-      mfc-spectre/mbcs/arm64: [ 124, 126 ]
-      mfc-spectre/mbcs/x64: [ 125, 127 ]
+      mfc-spectre/mbcs/arm: [ 121, 122 ]
+      mfc-spectre/mbcs/arm64: [ 123, 125 ]
+      mfc-spectre/mbcs/x64: [ 127, 128 ]
       mfc-spectre/mbcs/x86: [ 129, 130 ]
       mfc-spectre/unicode:
         [131,132,133,134,135,136,137,138,139,          140
         ]
       mfc-spectre/unicode/arm: [ 131, 132 ]
-      mfc-spectre/unicode/arm64: [ 133, 135 ]
-      mfc-spectre/unicode/x64: [ 137, 138 ]
+      mfc-spectre/unicode/arm64: [ 133, 134 ]
+      mfc-spectre/unicode/x64: [ 136, 137 ]
       mfc-spectre/unicode/x86: [ 139, 140 ]
       mfc/mbcs: [ 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 ]
       mfc/mbcs/arm: [ 99, 100 ]
-      mfc/mbcs/arm64: [ 102, 103 ]
-      mfc/mbcs/x64: [ 105, 106 ]
+      mfc/mbcs/arm64: [ 101, 103 ]
+      mfc/mbcs/x64: [ 104, 105 ]
       mfc/mbcs/x86: [ 107, 108 ]
       mfc/unicode:
         [109,110,111,112,113,114,115,116,117,          118
         ]
-      mfc/unicode/arm: [ 109, 110 ]
-      mfc/unicode/arm64: [ 111, 113 ]
-      mfc/unicode/x64: [ 115, 116 ]
+      mfc/unicode/arm: [ 111, 113 ]
+      mfc/unicode/arm64: [ 109, 110 ]
+      mfc/unicode/x64: [ 114, 115 ]
       mfc/unicode/x86: [ 117, 118 ]
       microsoft:
-        [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,53,54,55,56,57,58,59,61,62,63,64,65,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,          180
+        [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,52,53,54,55,56,57,58,59,61,62,64,65,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
       microsoft.visualstudio:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       microsoft.visualstudio.vc:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       microsoft.visualstudio.vc.msbuild:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       microsoft.visualstudio.vc.msbuild.v170:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      microsoft.visualstudio.vc.msbuild.v170.arm: [ 53, 54, 55 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm: [ 52, 53, 55 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.uwp: [ 55 ]
       microsoft.visualstudio.vc.msbuild.v170.arm.v143: [ 53 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64: [ 56, 57, 58 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 58 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 57 ]
-      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 59, 67, 68 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64: [ 54, 56, 58 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.uwp: [ 54 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      microsoft.visualstudio.vc.msbuild.v170.arm64ec: [ 57, 67, 68 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 67 ]
       microsoft.visualstudio.vc.msbuild.v170.arm64ec.v143: [ 68 ]
       microsoft.visualstudio.vc.msbuild.v170.base: [ 69, 70 ]
-      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64: [ 71, 72, 73 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
-      microsoft.visualstudio.vc.msbuild.v170.x86: [ 74, 75, 76 ]
+      microsoft.visualstudio.vc.msbuild.v170.base.uwp: [ 69 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64: [ 71, 72, 74 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.uwp: [ 74 ]
+      microsoft.visualstudio.vc.msbuild.v170.x64.v143: [ 72 ]
+      microsoft.visualstudio.vc.msbuild.v170.x86: [ 73, 75, 76 ]
       microsoft.visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
       microsoft.visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
       microsoft/asan: [ 1, 2, 3, 4, 5, 6 ]
-      microsoft/asan/x64: [ 1, 2 ]
+      microsoft/asan/x64: [ 3, 4 ]
       microsoft/asan/x86: [ 5, 6 ]
       microsoft/atl:
         [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,          98
@@ -288,11 +288,11 @@ indexes:
       microsoft/atl-headers: [ 87, 88 ]
       microsoft/atl-spectre: [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98 ]
       microsoft/atl-spectre/arm: [ 89, 90 ]
-      microsoft/atl-spectre/arm64: [ 91, 94 ]
-      microsoft/atl-spectre/x64: [ 95, 96 ]
-      microsoft/atl-spectre/x86: [ 97, 98 ]
-      microsoft/atl/arm: [ 79, 80 ]
-      microsoft/atl/arm64: [ 77, 78 ]
+      microsoft/atl-spectre/arm64: [ 91, 92 ]
+      microsoft/atl-spectre/x64: [ 97, 98 ]
+      microsoft/atl-spectre/x86: [ 95, 96 ]
+      microsoft/atl/arm: [ 77, 78 ]
+      microsoft/atl/arm64: [ 79, 80 ]
       microsoft/atl/x64: [ 83, 84 ]
       microsoft/atl/x86: [ 85, 86 ]
       microsoft/desktop:
@@ -300,14 +300,14 @@ indexes:
         ]
       microsoft/desktop-spectre: [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
       microsoft/desktop-spectre/arm: [ 17, 18 ]
-      microsoft/desktop-spectre/arm64: [ 19, 21 ]
-      microsoft/desktop-spectre/x64: [ 23, 24 ]
+      microsoft/desktop-spectre/arm64: [ 19, 20 ]
+      microsoft/desktop-spectre/x64: [ 22, 23 ]
       microsoft/desktop-spectre/x86: [ 25, 26 ]
       microsoft/desktop/arm: [ 7, 8 ]
-      microsoft/desktop/arm64: [ 9, 10 ]
-      microsoft/desktop/x64: [ 12, 14 ]
+      microsoft/desktop/arm64: [ 9, 12 ]
+      microsoft/desktop/x64: [ 13, 14 ]
       microsoft/desktop/x86: [ 15, 16 ]
-      microsoft/diasdk: [ 152, 153 ]
+      microsoft/diasdk: [ 154, 155 ]
       microsoft/headers: [ 27, 28 ]
       microsoft/mfc:
         [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
@@ -319,135 +319,135 @@ indexes:
       microsoft/mfc-spectre/mbcs:
         [121,122,123,124,125,126,127,128,129,          130
         ]
-      microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
-      microsoft/mfc-spectre/mbcs/arm64: [ 124, 126 ]
-      microsoft/mfc-spectre/mbcs/x64: [ 125, 127 ]
+      microsoft/mfc-spectre/mbcs/arm: [ 121, 122 ]
+      microsoft/mfc-spectre/mbcs/arm64: [ 123, 125 ]
+      microsoft/mfc-spectre/mbcs/x64: [ 127, 128 ]
       microsoft/mfc-spectre/mbcs/x86: [ 129, 130 ]
       microsoft/mfc-spectre/unicode:
         [131,132,133,134,135,136,137,138,139,          140
         ]
       microsoft/mfc-spectre/unicode/arm: [ 131, 132 ]
-      microsoft/mfc-spectre/unicode/arm64: [ 133, 135 ]
-      microsoft/mfc-spectre/unicode/x64: [ 137, 138 ]
+      microsoft/mfc-spectre/unicode/arm64: [ 133, 134 ]
+      microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
       microsoft/mfc-spectre/unicode/x86: [ 139, 140 ]
       microsoft/mfc/mbcs: [ 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 ]
       microsoft/mfc/mbcs/arm: [ 99, 100 ]
-      microsoft/mfc/mbcs/arm64: [ 102, 103 ]
-      microsoft/mfc/mbcs/x64: [ 105, 106 ]
+      microsoft/mfc/mbcs/arm64: [ 101, 103 ]
+      microsoft/mfc/mbcs/x64: [ 104, 105 ]
       microsoft/mfc/mbcs/x86: [ 107, 108 ]
       microsoft/mfc/unicode:
         [109,110,111,112,113,114,115,116,117,          118
         ]
-      microsoft/mfc/unicode/arm: [ 109, 110 ]
-      microsoft/mfc/unicode/arm64: [ 111, 113 ]
-      microsoft/mfc/unicode/x64: [ 115, 116 ]
+      microsoft/mfc/unicode/arm: [ 111, 113 ]
+      microsoft/mfc/unicode/arm64: [ 109, 110 ]
+      microsoft/mfc/unicode/x64: [ 114, 115 ]
       microsoft/mfc/unicode/x86: [ 117, 118 ]
-      microsoft/msbuild: [ 63, 64, 65 ]
-      microsoft/msbuild/vc: [ 63, 64, 65 ]
+      microsoft/msbuild: [ 62, 64, 65 ]
+      microsoft/msbuild/vc: [ 62, 64, 65 ]
       microsoft/msbuild/vc/Desktop: [ 65 ]
       microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      microsoft/msbuild/vc/uwp: [ 64 ]
-      microsoft/msbuild/vc/v143: [ 63 ]
+      microsoft/msbuild/vc/uwp: [ 62 ]
+      microsoft/msbuild/vc/v143: [ 64 ]
       microsoft/msvc:
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      microsoft/msvc/x64_arm: [ 160, 161 ]
-      microsoft/msvc/x64_arm64: [ 166, 167 ]
-      microsoft/msvc/x64_x64: [ 163, 164 ]
-      microsoft/msvc/x64_x86: [ 169, 170 ]
-      microsoft/msvc/x86_arm: [ 172, 173 ]
+      microsoft/msvc/x64_arm: [ 162, 163 ]
+      microsoft/msvc/x64_arm64: [ 169, 170 ]
+      microsoft/msvc/x64_x64: [ 166, 167 ]
+      microsoft/msvc/x64_x86: [ 171, 172 ]
+      microsoft/msvc/x86_arm: [ 173, 174 ]
       microsoft/msvc/x86_arm64: [ 179, 180 ]
       microsoft/msvc/x86_x64: [ 177, 178 ]
       microsoft/msvc/x86_x86: [ 175, 176 ]
       microsoft/onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
-      microsoft/onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
-      microsoft/onecore-spectre/arm: [ 39, 40 ]
-      microsoft/onecore-spectre/arm64: [ 41, 42 ]
-      microsoft/onecore-spectre/x64: [ 45, 46 ]
-      microsoft/onecore-spectre/x86: [ 47, 48 ]
-      microsoft/onecore/arm: [ 29, 30 ]
-      microsoft/onecore/arm64: [ 31, 32 ]
-      microsoft/onecore/x64: [ 35, 36 ]
-      microsoft/onecore/x86: [ 37, 38 ]
-      microsoft/openocd: [ 61, 62 ]
+      microsoft/onecore-spectre: [ 29, 30, 31, 32, 33, 34, 35, 36, 37, 38 ]
+      microsoft/onecore-spectre/arm: [ 29, 30 ]
+      microsoft/onecore-spectre/arm64: [ 31, 32 ]
+      microsoft/onecore-spectre/x64: [ 35, 36 ]
+      microsoft/onecore-spectre/x86: [ 37, 38 ]
+      microsoft/onecore/arm: [ 39, 40 ]
+      microsoft/onecore/arm64: [ 41, 43 ]
+      microsoft/onecore/x64: [ 45, 46 ]
+      microsoft/onecore/x86: [ 47, 48 ]
+      microsoft/openocd: [ 59, 61 ]
       microsoft/windows:
-        [141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
       microsoft/windows/windows:
-        [145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
-      microsoft/windows/windows.arm: [ 145, 146, 171, 174 ]
-      microsoft/windows/windows.arm64: [ 147, 148, 149, 151 ]
-      microsoft/windows/windows.x64: [ 150, 154, 157, 158 ]
-      microsoft/windows/windows.x86: [ 159, 162, 165, 168 ]
+      microsoft/windows/windows.arm: [ 145, 146, 164, 168 ]
+      microsoft/windows/windows.arm64: [ 147, 148, 149, 150 ]
+      microsoft/windows/windows.x64: [ 151, 152, 153, 156 ]
+      microsoft/windows/windows.x86: [ 157, 160, 161, 165 ]
       msbuild:
-        [53,54,55,56,57,58,59,63,64,65,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,62,64,65,67,68,69,70,71,72,73,74,75,          76
         ]
       msbuild.v170:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      msbuild.v170.arm: [ 53, 54, 55 ]
+      msbuild.v170.arm: [ 52, 53, 55 ]
       msbuild.v170.arm.uwp: [ 55 ]
       msbuild.v170.arm.v143: [ 53 ]
-      msbuild.v170.arm64: [ 56, 57, 58 ]
-      msbuild.v170.arm64.uwp: [ 58 ]
-      msbuild.v170.arm64.v143: [ 57 ]
-      msbuild.v170.arm64ec: [ 59, 67, 68 ]
+      msbuild.v170.arm64: [ 54, 56, 58 ]
+      msbuild.v170.arm64.uwp: [ 54 ]
+      msbuild.v170.arm64.v143: [ 58 ]
+      msbuild.v170.arm64ec: [ 57, 67, 68 ]
       msbuild.v170.arm64ec.uwp: [ 67 ]
       msbuild.v170.arm64ec.v143: [ 68 ]
       msbuild.v170.base: [ 69, 70 ]
-      msbuild.v170.base.uwp: [ 70 ]
-      msbuild.v170.x64: [ 71, 72, 73 ]
-      msbuild.v170.x64.uwp: [ 72 ]
-      msbuild.v170.x64.v143: [ 73 ]
-      msbuild.v170.x86: [ 74, 75, 76 ]
+      msbuild.v170.base.uwp: [ 69 ]
+      msbuild.v170.x64: [ 71, 72, 74 ]
+      msbuild.v170.x64.uwp: [ 74 ]
+      msbuild.v170.x64.v143: [ 72 ]
+      msbuild.v170.x86: [ 73, 75, 76 ]
       msbuild.v170.x86.uwp: [ 75 ]
       msbuild.v170.x86.v143: [ 76 ]
-      msbuild/vc: [ 63, 64, 65 ]
+      msbuild/vc: [ 62, 64, 65 ]
       msbuild/vc/Desktop: [ 65 ]
       msbuild/vc/Desktop/v143: [ 65 ]
-      msbuild/vc/uwp: [ 64 ]
-      msbuild/vc/v143: [ 63 ]
+      msbuild/vc/uwp: [ 62 ]
+      msbuild/vc/v143: [ 64 ]
       msvc:
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      msvc/x64_arm: [ 160, 161 ]
-      msvc/x64_arm64: [ 166, 167 ]
-      msvc/x64_x64: [ 163, 164 ]
-      msvc/x64_x86: [ 169, 170 ]
-      msvc/x86_arm: [ 172, 173 ]
+      msvc/x64_arm: [ 162, 163 ]
+      msvc/x64_arm64: [ 169, 170 ]
+      msvc/x64_x64: [ 166, 167 ]
+      msvc/x64_x86: [ 171, 172 ]
+      msvc/x86_arm: [ 173, 174 ]
       msvc/x86_arm64: [ 179, 180 ]
       msvc/x86_x64: [ 177, 178 ]
       msvc/x86_x86: [ 175, 176 ]
-      ninja: [ 60 ]
-      ninja-build: [ 60 ]
-      ninja-build/ninja: [ 60 ]
+      ninja: [ 66 ]
+      ninja-build: [ 66 ]
+      ninja-build/ninja: [ 66 ]
       onecore:
         [29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
-      onecore-spectre: [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
-      onecore-spectre/arm: [ 39, 40 ]
-      onecore-spectre/arm64: [ 41, 42 ]
-      onecore-spectre/x64: [ 45, 46 ]
-      onecore-spectre/x86: [ 47, 48 ]
-      onecore/arm: [ 29, 30 ]
-      onecore/arm64: [ 31, 32 ]
-      onecore/x64: [ 35, 36 ]
-      onecore/x86: [ 37, 38 ]
-      openocd: [ 61, 62 ]
-      pico: [ 66 ]
-      pico-sdk: [ 66 ]
-      raspberrypi: [ 66 ]
-      raspberrypi/pico: [ 66 ]
-      raspberrypi/pico-sdk: [ 66 ]
-      sdk: [ 66 ]
+      onecore-spectre: [ 29, 30, 31, 32, 33, 34, 35, 36, 37, 38 ]
+      onecore-spectre/arm: [ 29, 30 ]
+      onecore-spectre/arm64: [ 31, 32 ]
+      onecore-spectre/x64: [ 35, 36 ]
+      onecore-spectre/x86: [ 37, 38 ]
+      onecore/arm: [ 39, 40 ]
+      onecore/arm64: [ 41, 43 ]
+      onecore/x64: [ 45, 46 ]
+      onecore/x86: [ 47, 48 ]
+      openocd: [ 59, 61 ]
+      pico: [ 63 ]
+      pico-sdk: [ 63 ]
+      raspberrypi: [ 63 ]
+      raspberrypi/pico: [ 63 ]
+      raspberrypi/pico-sdk: [ 63 ]
+      sdk: [ 63 ]
       sdks:
-        [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
       sdks/microsoft:
-        [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
       sdks/microsoft/atl:
         [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,          98
@@ -455,11 +455,11 @@ indexes:
       sdks/microsoft/atl-headers: [ 87, 88 ]
       sdks/microsoft/atl-spectre: [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98 ]
       sdks/microsoft/atl-spectre/arm: [ 89, 90 ]
-      sdks/microsoft/atl-spectre/arm64: [ 91, 94 ]
-      sdks/microsoft/atl-spectre/x64: [ 95, 96 ]
-      sdks/microsoft/atl-spectre/x86: [ 97, 98 ]
-      sdks/microsoft/atl/arm: [ 79, 80 ]
-      sdks/microsoft/atl/arm64: [ 77, 78 ]
+      sdks/microsoft/atl-spectre/arm64: [ 91, 92 ]
+      sdks/microsoft/atl-spectre/x64: [ 97, 98 ]
+      sdks/microsoft/atl-spectre/x86: [ 95, 96 ]
+      sdks/microsoft/atl/arm: [ 77, 78 ]
+      sdks/microsoft/atl/arm64: [ 79, 80 ]
       sdks/microsoft/atl/x64: [ 83, 84 ]
       sdks/microsoft/atl/x86: [ 85, 86 ]
       sdks/microsoft/mfc:
@@ -472,227 +472,227 @@ indexes:
       sdks/microsoft/mfc-spectre/mbcs:
         [121,122,123,124,125,126,127,128,129,          130
         ]
-      sdks/microsoft/mfc-spectre/mbcs/arm: [ 122, 123 ]
-      sdks/microsoft/mfc-spectre/mbcs/arm64: [ 124, 126 ]
-      sdks/microsoft/mfc-spectre/mbcs/x64: [ 125, 127 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm: [ 121, 122 ]
+      sdks/microsoft/mfc-spectre/mbcs/arm64: [ 123, 125 ]
+      sdks/microsoft/mfc-spectre/mbcs/x64: [ 127, 128 ]
       sdks/microsoft/mfc-spectre/mbcs/x86: [ 129, 130 ]
       sdks/microsoft/mfc-spectre/unicode:
         [131,132,133,134,135,136,137,138,139,          140
         ]
       sdks/microsoft/mfc-spectre/unicode/arm: [ 131, 132 ]
-      sdks/microsoft/mfc-spectre/unicode/arm64: [ 133, 135 ]
-      sdks/microsoft/mfc-spectre/unicode/x64: [ 137, 138 ]
+      sdks/microsoft/mfc-spectre/unicode/arm64: [ 133, 134 ]
+      sdks/microsoft/mfc-spectre/unicode/x64: [ 136, 137 ]
       sdks/microsoft/mfc-spectre/unicode/x86: [ 139, 140 ]
       sdks/microsoft/mfc/mbcs: [ 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 ]
       sdks/microsoft/mfc/mbcs/arm: [ 99, 100 ]
-      sdks/microsoft/mfc/mbcs/arm64: [ 102, 103 ]
-      sdks/microsoft/mfc/mbcs/x64: [ 105, 106 ]
+      sdks/microsoft/mfc/mbcs/arm64: [ 101, 103 ]
+      sdks/microsoft/mfc/mbcs/x64: [ 104, 105 ]
       sdks/microsoft/mfc/mbcs/x86: [ 107, 108 ]
       sdks/microsoft/mfc/unicode:
         [109,110,111,112,113,114,115,116,117,          118
         ]
-      sdks/microsoft/mfc/unicode/arm: [ 109, 110 ]
-      sdks/microsoft/mfc/unicode/arm64: [ 111, 113 ]
-      sdks/microsoft/mfc/unicode/x64: [ 115, 116 ]
+      sdks/microsoft/mfc/unicode/arm: [ 111, 113 ]
+      sdks/microsoft/mfc/unicode/arm64: [ 109, 110 ]
+      sdks/microsoft/mfc/unicode/x64: [ 114, 115 ]
       sdks/microsoft/mfc/unicode/x86: [ 117, 118 ]
       sdks/microsoft/windows:
-        [141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
       sdks/microsoft/windows/windows:
-        [145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
-      sdks/microsoft/windows/windows.arm: [ 145, 146, 171, 174 ]
-      sdks/microsoft/windows/windows.arm64: [ 147, 148, 149, 151 ]
-      sdks/microsoft/windows/windows.x64: [ 150, 154, 157, 158 ]
-      sdks/microsoft/windows/windows.x86: [ 159, 162, 165, 168 ]
+      sdks/microsoft/windows/windows.arm: [ 145, 146, 164, 168 ]
+      sdks/microsoft/windows/windows.arm64: [ 147, 148, 149, 150 ]
+      sdks/microsoft/windows/windows.x64: [ 151, 152, 153, 156 ]
+      sdks/microsoft/windows/windows.x86: [ 157, 160, 161, 165 ]
       spectre:
-        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,48,89,90,91,92,93,94,95,96,97,98,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
+        [17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,89,90,91,92,93,94,95,96,97,98,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
         ]
-      spectre/arm: [ 17, 18, 39, 40, 89, 90 ]
-      spectre/arm64: [ 19, 21, 41, 42, 91, 94 ]
+      spectre/arm: [ 17, 18, 29, 30, 89, 90 ]
+      spectre/arm64: [ 19, 20, 31, 32, 91, 92 ]
       spectre/mbcs:
         [121,122,123,124,125,126,127,128,129,          130
         ]
-      spectre/mbcs/arm: [ 122, 123 ]
-      spectre/mbcs/arm64: [ 124, 126 ]
-      spectre/mbcs/x64: [ 125, 127 ]
+      spectre/mbcs/arm: [ 121, 122 ]
+      spectre/mbcs/arm64: [ 123, 125 ]
+      spectre/mbcs/x64: [ 127, 128 ]
       spectre/mbcs/x86: [ 129, 130 ]
       spectre/unicode:
         [131,132,133,134,135,136,137,138,139,          140
         ]
       spectre/unicode/arm: [ 131, 132 ]
-      spectre/unicode/arm64: [ 133, 135 ]
-      spectre/unicode/x64: [ 137, 138 ]
+      spectre/unicode/arm64: [ 133, 134 ]
+      spectre/unicode/x64: [ 136, 137 ]
       spectre/unicode/x86: [ 139, 140 ]
-      spectre/x64: [ 23, 24, 45, 46, 95, 96 ]
-      spectre/x86: [ 25, 26, 47, 48, 97, 98 ]
+      spectre/x64: [ 22, 23, 35, 36, 97, 98 ]
+      spectre/x86: [ 25, 26, 37, 38, 95, 96 ]
       termite: [ 51 ]
-      tools: [ 49, 50, 51, 52, 60, 61, 62, 63, 64, 65 ]
+      tools: [ 49, 50, 51, 59, 60, 61, 62, 64, 65, 66 ]
       tools/arduino: [ 49, 50 ]
       tools/arduino/arduino: [ 49, 50 ]
       tools/arduino/arduino-cli: [ 50 ]
       tools/arduino/arduino-ide: [ 49 ]
       tools/compuphase: [ 51 ]
       tools/compuphase/termite: [ 51 ]
-      tools/kitware: [ 52 ]
-      tools/kitware/cmake: [ 52 ]
-      tools/microsoft: [ 61, 62, 63, 64, 65 ]
-      tools/microsoft/msbuild: [ 63, 64, 65 ]
-      tools/microsoft/msbuild/vc: [ 63, 64, 65 ]
+      tools/kitware: [ 60 ]
+      tools/kitware/cmake: [ 60 ]
+      tools/microsoft: [ 59, 61, 62, 64, 65 ]
+      tools/microsoft/msbuild: [ 62, 64, 65 ]
+      tools/microsoft/msbuild/vc: [ 62, 64, 65 ]
       tools/microsoft/msbuild/vc/Desktop: [ 65 ]
       tools/microsoft/msbuild/vc/Desktop/v143: [ 65 ]
-      tools/microsoft/msbuild/vc/uwp: [ 64 ]
-      tools/microsoft/msbuild/vc/v143: [ 63 ]
-      tools/microsoft/openocd: [ 61, 62 ]
-      tools/ninja: [ 60 ]
-      tools/ninja-build: [ 60 ]
-      tools/ninja-build/ninja: [ 60 ]
+      tools/microsoft/msbuild/vc/uwp: [ 62 ]
+      tools/microsoft/msbuild/vc/v143: [ 64 ]
+      tools/microsoft/openocd: [ 59, 61 ]
+      tools/ninja: [ 66 ]
+      tools/ninja-build: [ 66 ]
+      tools/ninja-build/ninja: [ 66 ]
       unicode:
         [109,110,111,112,113,114,115,116,117,118,131,132,133,134,135,136,137,138,139,          140
         ]
-      unicode/arm: [ 109, 110, 131, 132 ]
-      unicode/arm64: [ 111, 113, 133, 135 ]
-      unicode/x64: [ 115, 116, 137, 138 ]
+      unicode/arm: [ 111, 113, 131, 132 ]
+      unicode/arm64: [ 109, 110, 133, 134 ]
+      unicode/x64: [ 114, 115, 136, 137 ]
       unicode/x86: [ 117, 118, 139, 140 ]
-      uwp: [ 55, 58, 64, 67, 70, 72, 75 ]
-      v143: [ 53, 57, 63, 65, 68, 73, 76 ]
+      uwp: [ 54, 55, 62, 67, 69, 74, 75 ]
+      v143: [ 53, 58, 64, 65, 68, 72, 76 ]
       v170:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      v170.arm: [ 53, 54, 55 ]
+      v170.arm: [ 52, 53, 55 ]
       v170.arm.uwp: [ 55 ]
       v170.arm.v143: [ 53 ]
-      v170.arm64: [ 56, 57, 58 ]
-      v170.arm64.uwp: [ 58 ]
-      v170.arm64.v143: [ 57 ]
-      v170.arm64ec: [ 59, 67, 68 ]
+      v170.arm64: [ 54, 56, 58 ]
+      v170.arm64.uwp: [ 54 ]
+      v170.arm64.v143: [ 58 ]
+      v170.arm64ec: [ 57, 67, 68 ]
       v170.arm64ec.uwp: [ 67 ]
       v170.arm64ec.v143: [ 68 ]
       v170.base: [ 69, 70 ]
-      v170.base.uwp: [ 70 ]
-      v170.x64: [ 71, 72, 73 ]
-      v170.x64.uwp: [ 72 ]
-      v170.x64.v143: [ 73 ]
-      v170.x86: [ 74, 75, 76 ]
+      v170.base.uwp: [ 69 ]
+      v170.x64: [ 71, 72, 74 ]
+      v170.x64.uwp: [ 74 ]
+      v170.x64.v143: [ 72 ]
+      v170.x86: [ 73, 75, 76 ]
       v170.x86.uwp: [ 75 ]
       v170.x86.v143: [ 76 ]
       vc:
-        [53,54,55,56,57,58,59,63,64,65,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,62,64,65,67,68,69,70,71,72,73,74,75,          76
         ]
       vc.msbuild:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       vc.msbuild.v170:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      vc.msbuild.v170.arm: [ 53, 54, 55 ]
+      vc.msbuild.v170.arm: [ 52, 53, 55 ]
       vc.msbuild.v170.arm.uwp: [ 55 ]
       vc.msbuild.v170.arm.v143: [ 53 ]
-      vc.msbuild.v170.arm64: [ 56, 57, 58 ]
-      vc.msbuild.v170.arm64.uwp: [ 58 ]
-      vc.msbuild.v170.arm64.v143: [ 57 ]
-      vc.msbuild.v170.arm64ec: [ 59, 67, 68 ]
+      vc.msbuild.v170.arm64: [ 54, 56, 58 ]
+      vc.msbuild.v170.arm64.uwp: [ 54 ]
+      vc.msbuild.v170.arm64.v143: [ 58 ]
+      vc.msbuild.v170.arm64ec: [ 57, 67, 68 ]
       vc.msbuild.v170.arm64ec.uwp: [ 67 ]
       vc.msbuild.v170.arm64ec.v143: [ 68 ]
       vc.msbuild.v170.base: [ 69, 70 ]
-      vc.msbuild.v170.base.uwp: [ 70 ]
-      vc.msbuild.v170.x64: [ 71, 72, 73 ]
-      vc.msbuild.v170.x64.uwp: [ 72 ]
-      vc.msbuild.v170.x64.v143: [ 73 ]
-      vc.msbuild.v170.x86: [ 74, 75, 76 ]
+      vc.msbuild.v170.base.uwp: [ 69 ]
+      vc.msbuild.v170.x64: [ 71, 72, 74 ]
+      vc.msbuild.v170.x64.uwp: [ 74 ]
+      vc.msbuild.v170.x64.v143: [ 72 ]
+      vc.msbuild.v170.x86: [ 73, 75, 76 ]
       vc.msbuild.v170.x86.uwp: [ 75 ]
       vc.msbuild.v170.x86.v143: [ 76 ]
       vc/Desktop: [ 65 ]
       vc/Desktop/v143: [ 65 ]
-      vc/uwp: [ 64 ]
-      vc/v143: [ 63 ]
+      vc/uwp: [ 62 ]
+      vc/v143: [ 64 ]
       visualstudio:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       visualstudio.vc:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       visualstudio.vc.msbuild:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       visualstudio.vc.msbuild.v170:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      visualstudio.vc.msbuild.v170.arm: [ 53, 54, 55 ]
+      visualstudio.vc.msbuild.v170.arm: [ 52, 53, 55 ]
       visualstudio.vc.msbuild.v170.arm.uwp: [ 55 ]
       visualstudio.vc.msbuild.v170.arm.v143: [ 53 ]
-      visualstudio.vc.msbuild.v170.arm64: [ 56, 57, 58 ]
-      visualstudio.vc.msbuild.v170.arm64.uwp: [ 58 ]
-      visualstudio.vc.msbuild.v170.arm64.v143: [ 57 ]
-      visualstudio.vc.msbuild.v170.arm64ec: [ 59, 67, 68 ]
+      visualstudio.vc.msbuild.v170.arm64: [ 54, 56, 58 ]
+      visualstudio.vc.msbuild.v170.arm64.uwp: [ 54 ]
+      visualstudio.vc.msbuild.v170.arm64.v143: [ 58 ]
+      visualstudio.vc.msbuild.v170.arm64ec: [ 57, 67, 68 ]
       visualstudio.vc.msbuild.v170.arm64ec.uwp: [ 67 ]
       visualstudio.vc.msbuild.v170.arm64ec.v143: [ 68 ]
       visualstudio.vc.msbuild.v170.base: [ 69, 70 ]
-      visualstudio.vc.msbuild.v170.base.uwp: [ 70 ]
-      visualstudio.vc.msbuild.v170.x64: [ 71, 72, 73 ]
-      visualstudio.vc.msbuild.v170.x64.uwp: [ 72 ]
-      visualstudio.vc.msbuild.v170.x64.v143: [ 73 ]
-      visualstudio.vc.msbuild.v170.x86: [ 74, 75, 76 ]
+      visualstudio.vc.msbuild.v170.base.uwp: [ 69 ]
+      visualstudio.vc.msbuild.v170.x64: [ 71, 72, 74 ]
+      visualstudio.vc.msbuild.v170.x64.uwp: [ 74 ]
+      visualstudio.vc.msbuild.v170.x64.v143: [ 72 ]
+      visualstudio.vc.msbuild.v170.x86: [ 73, 75, 76 ]
       visualstudio.vc.msbuild.v170.x86.uwp: [ 75 ]
       visualstudio.vc.msbuild.v170.x86.v143: [ 76 ]
       windows:
-        [141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
-      windows.arm: [ 145, 146, 171, 174 ]
-      windows.arm64: [ 147, 148, 149, 151 ]
-      windows.x64: [ 150, 154, 157, 158 ]
-      windows.x86: [ 159, 162, 165, 168 ]
+      windows.arm: [ 145, 146, 164, 168 ]
+      windows.arm64: [ 147, 148, 149, 150 ]
+      windows.x64: [ 151, 152, 153, 156 ]
+      windows.x86: [ 157, 160, 161, 165 ]
       windows/windows:
-        [145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
-      windows/windows.arm: [ 145, 146, 171, 174 ]
-      windows/windows.arm64: [ 147, 148, 149, 151 ]
-      windows/windows.x64: [ 150, 154, 157, 158 ]
-      windows/windows.x86: [ 159, 162, 165, 168 ]
+      windows/windows.arm: [ 145, 146, 164, 168 ]
+      windows/windows.arm64: [ 147, 148, 149, 150 ]
+      windows/windows.x64: [ 151, 152, 153, 156 ]
+      windows/windows.x86: [ 157, 160, 161, 165 ]
       x64:
-        [1,2,12,14,23,24,35,36,45,46,71,72,73,83,84,95,96,105,106,115,116,125,127,137,138,150,154,157,          158
+        [3,4,13,14,22,23,35,36,45,46,71,72,74,83,84,97,98,104,105,114,115,127,128,136,137,151,152,153,          156
         ]
-      x64.uwp: [ 72 ]
-      x64.v143: [ 73 ]
-      x64_arm: [ 160, 161 ]
-      x64_arm64: [ 166, 167 ]
-      x64_x64: [ 163, 164 ]
-      x64_x86: [ 169, 170 ]
+      x64.uwp: [ 74 ]
+      x64.v143: [ 72 ]
+      x64_arm: [ 162, 163 ]
+      x64_arm64: [ 169, 170 ]
+      x64_x64: [ 166, 167 ]
+      x64_x86: [ 171, 172 ]
       x86:
-        [5,6,15,16,25,26,37,38,47,48,74,75,76,85,86,97,98,107,108,117,118,129,130,139,140,159,162,165,          168
+        [5,6,15,16,25,26,37,38,47,48,73,75,76,85,86,95,96,107,108,117,118,129,130,139,140,157,160,161,          165
         ]
       x86.uwp: [ 75 ]
       x86.v143: [ 76 ]
-      x86_arm: [ 172, 173 ]
+      x86_arm: [ 173, 174 ]
       x86_arm64: [ 179, 180 ]
       x86_x64: [ 177, 178 ]
       x86_x86: [ 175, 176 ]
   SemverKey/version:
     keys:
-      0.11.0-ms1: [ 62 ]
-      0.11.0: [ 61 ]
+      0.11.0-ms1: [ 61 ]
+      0.11.0: [ 59 ]
       0.18.3: [ 50 ]
-      1.3.0: [ 66 ]
-      1.10.2: [ 60 ]
+      1.3.0: [ 63 ]
+      1.10.2: [ 66 ]
       1.18.15: [ 49 ]
       3.4.0: [ 51 ]
-      3.20.1: [ 52 ]
-      10.0.17763: [ 141, 146, 147, 150, 159 ]
-      10.0.18362: [ 142, 148, 154, 162, 174 ]
-      10.0.19041: [ 143, 149, 157, 165, 171 ]
-      10.0.22621: [ 144, 145, 151, 158, 168 ]
-      14.28.29912: [ 28 ]
+      3.20.1: [ 60 ]
+      10.0.17763: [ 141, 145, 147, 152, 157 ]
+      10.0.18362: [ 143, 148, 151, 160, 164 ]
+      10.0.19041: [ 144, 149, 153, 161, 168 ]
+      10.0.22621: [ 142, 146, 150, 156, 165 ]
+      14.28.29912: [ 27 ]
       14.28.29914:
-        [78,79,81,83,86,87,90,91,93,95,98,99,101,103,105,108,109,112,113,116,117,120,121,122,124,127,130,132,133,134,137,          139
+        [77,80,81,83,86,88,90,91,93,95,98,99,102,103,104,107,109,111,112,114,117,120,122,124,125,127,129,131,133,135,137,          139
         ]
       14.28.29915:
-        [2,4,5,7,10,11,12,16,17,19,20,24,25,30,32,34,35,38,39,42,43,45,47,152,156,161,164,167,170,173,175,177,          179
+        [2,3,5,7,9,10,14,15,17,19,22,24,26,29,32,33,36,38,39,43,44,46,48,155,159,163,167,170,171,174,175,177,          179
         ]
       14.29.30037:
-        [1,3,6,8,9,13,14,15,18,21,22,23,26,27,29,31,33,36,37,40,41,44,46,48,77,80,82,84,85,88,89,92,94,96,97,100,102,104,106,107,110,111,114,115,118,119,123,125,126,128,129,131,135,136,138,140,153,155,160,163,166,169,172,176,178,          180
+        [1,4,6,8,11,12,13,16,18,20,21,23,25,28,30,31,34,35,37,40,41,42,45,47,78,79,82,84,85,87,89,92,94,96,97,100,101,105,106,108,110,113,115,116,118,119,121,123,126,128,130,132,134,136,138,140,154,158,162,166,169,172,173,176,178,          180
         ]
       17.0.0:
-        [53,54,55,56,57,58,59,63,64,65,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,62,64,65,67,68,69,70,71,72,73,74,75,          76
         ]
       2020.10.0: [ 0 ]
   StringKey/summary:
@@ -701,12 +701,12 @@ indexes:
       Active Template Library Headers: [ 87, 88 ]
       Active Template Library w/ Spectre mitigations: [ 89, 90, 91, 92, 93, 94, 95, 96, 97, 98 ]
       Arduino IDE: [ 49, 50 ]
-      C runtime headers: [ 27 ]
-      C runtime headers.: [ 28 ]
-      Debug Interface Access SDK: [ 152, 153 ]
-      Free and open on-chip debugging: [ 61, 62 ]
+      C runtime headers: [ 28 ]
+      C runtime headers.: [ 27 ]
+      Debug Interface Access SDK: [ 154, 155 ]
+      Free and open on-chip debugging: [ 59, 61 ]
       GCC compiler for ARM CPUs.: [ 0 ]
-      Kitware's cmake tool: [ 52 ]
+      Kitware's cmake tool: [ 60 ]
       Libraries supporting address sanitizer.: [ 1, 2, 3, 4, 5, 6 ]
       Microsoft Foundation Classes Headers: [ 119, 120 ]
       "Microsoft Foundation Classes, legacy MBCS libraries": [ 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 ]
@@ -720,38 +720,38 @@ indexes:
         [131,132,133,134,135,136,137,138,139,          140
         ]
       Microsoft Windows SDK: [ 141, 142, 143, 144 ]
-      Microsoft Windows SDK (targeting ARM): [ 145, 146, 171, 174 ]
-      Microsoft Windows SDK (targeting ARM64): [ 147, 148, 149, 151 ]
-      Microsoft Windows SDK (targeting x64): [ 150, 154, 157, 158 ]
-      Microsoft Windows SDK (targeting x86): [ 159, 162, 165, 168 ]
-      Msbuild support for MSVC v143 toolset: [ 63, 65 ]
-      Msbuild support for MSVC v143 toolset for UWP: [ 64 ]
+      Microsoft Windows SDK (targeting ARM): [ 145, 146, 164, 168 ]
+      Microsoft Windows SDK (targeting ARM64): [ 147, 148, 149, 150 ]
+      Microsoft Windows SDK (targeting x64): [ 151, 152, 153, 156 ]
+      Microsoft Windows SDK (targeting x86): [ 157, 160, 161, 165 ]
+      Msbuild support for MSVC v143 toolset: [ 64, 65 ]
+      Msbuild support for MSVC v143 toolset for UWP: [ 62 ]
       MSBuild support for vc projects (generated from VS install):
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       "MSVC standard library libraries (desktop / kernel32, + spectre)": [ 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 ]
       MSVC standard library libraries (desktop / kernel32): [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
-      MSVC standard library libraries (desktop / onecore): [ 33, 37 ]
-      "MSVC standard library libraries (onecore / apisets, + spectre)": [ 39, 40, 41, 42, 43, 44, 45, 46, 47, 48 ]
-      MSVC standard library libraries (OneCore / apisets): [ 29, 30, 31, 32, 34, 35, 36, 38 ]
-      Ninja is a small build system with a focus on speed.: [ 60 ]
+      MSVC standard library libraries (desktop / onecore): [ 42, 47 ]
+      "MSVC standard library libraries (onecore / apisets, + spectre)": [ 29, 30, 31, 32, 33, 34, 35, 36, 37, 38 ]
+      MSVC standard library libraries (OneCore / apisets): [ 39, 40, 41, 43, 44, 45, 46, 48 ]
+      Ninja is a small build system with a focus on speed.: [ 66 ]
       Termite is an easy to use and easy to configure RS232 terminal.: [ 51 ]
       The Microsoft Visual C++ Compiler (MSVC):
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      The Raspberry Pi Pico SDK: [ 66 ]
+      The Raspberry Pi Pico SDK: [ 63 ]
     words:
-      ARM: [ 0, 145, 146, 171, 174 ]
-      ARM): [ 145, 146, 171, 174 ]
-      ARM64: [ 147, 148, 149, 151 ]
-      ARM64): [ 147, 148, 149, 151 ]
-      Access: [ 152, 153 ]
+      ARM: [ 0, 145, 146, 164, 168 ]
+      ARM): [ 145, 146, 164, 168 ]
+      ARM64: [ 147, 148, 149, 150 ]
+      ARM64): [ 147, 148, 149, 150 ]
+      Access: [ 154, 155 ]
       Active:
         [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,          98
         ]
       Arduino: [ 49, 50 ]
       C:
-        [27,28,155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [27,28,158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
       CPUs: [ 0 ]
       CPUs.: [ 0 ]
@@ -759,19 +759,19 @@ indexes:
         [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
         ]
       Compiler:
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      Debug: [ 152, 153 ]
+      Debug: [ 154, 155 ]
       Foundation:
         [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
         ]
-      Free: [ 61, 62 ]
+      Free: [ 59, 61 ]
       GCC: [ 0 ]
       Headers: [ 87, 88, 119, 120 ]
       IDE: [ 49, 50 ]
-      Interface: [ 152, 153 ]
-      Kitware: [ 52 ]
-      Kitware's: [ 52 ]
+      Interface: [ 154, 155 ]
+      Kitware: [ 60 ]
+      Kitware's: [ 60 ]
       Libraries: [ 1, 2, 3, 4, 5, 6 ]
       Library:
         [77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,          98
@@ -780,26 +780,26 @@ indexes:
         [99,100,101,102,103,104,105,106,107,108,121,122,123,124,125,126,127,128,129,          130
         ]
       MSBuild:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       MSVC:
-        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,63,64,65,155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,62,64,65,158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
       MSVC):
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
       Microsoft:
-        [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,          180
+        [99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      Msbuild: [ 63, 64, 65 ]
-      Ninja: [ 60 ]
-      OneCore: [ 29, 30, 31, 32, 34, 35, 36, 38 ]
-      Pi: [ 66 ]
-      Pico: [ 66 ]
+      Msbuild: [ 62, 64, 65 ]
+      Ninja: [ 66 ]
+      OneCore: [ 39, 40, 41, 43, 44, 45, 46, 48 ]
+      Pi: [ 63 ]
+      Pico: [ 63 ]
       RS232: [ 51 ]
-      Raspberry: [ 66 ]
+      Raspberry: [ 63 ]
       SDK:
-        [66,141,142,143,144,145,146,147,148,149,150,151,152,153,154,157,158,159,162,165,168,171,          174
+        [63,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,160,161,164,165,          168
         ]
       Spectre:
         [89,90,91,92,93,94,95,96,97,98,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
@@ -809,58 +809,58 @@ indexes:
         ]
       Termite: [ 51 ]
       The:
-        [66,155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [63,158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
-      UWP: [ 64 ]
+      UWP: [ 62 ]
       Unicode:
         [109,110,111,112,113,114,115,116,117,118,131,132,133,134,135,136,137,138,139,          140
         ]
       VS:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       Visual:
-        [155,156,160,161,163,164,166,167,169,170,172,173,175,176,177,178,179,          180
+        [158,159,162,163,166,167,169,170,171,172,173,174,175,176,177,178,179,          180
         ]
       Windows:
-        [141,142,143,144,145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [141,142,143,144,145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
-      a: [ 60 ]
+      a: [ 66 ]
       address: [ 1, 2, 3, 4, 5, 6 ]
       an: [ 51 ]
-      and: [ 51, 61, 62 ]
+      and: [ 51, 59, 61 ]
       apisets:
-        [29,30,31,32,34,35,36,38,39,40,41,42,43,44,45,46,47,          48
+        [29,30,31,32,33,34,35,36,37,38,39,40,41,43,44,45,46,          48
         ]
-      apisets): [ 29, 30, 31, 32, 34, 35, 36, 38 ]
-      build: [ 60 ]
-      chip: [ 61, 62 ]
-      cmake: [ 52 ]
+      apisets): [ 39, 40, 41, 43, 44, 45, 46, 48 ]
+      build: [ 66 ]
+      chip: [ 59, 61 ]
+      cmake: [ 60 ]
       compiler: [ 0 ]
       configure: [ 51 ]
-      debugging: [ 61, 62 ]
+      debugging: [ 59, 61 ]
       desktop:
-        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,          37
+        [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,42,          47
         ]
       easy: [ 51 ]
-      focus: [ 60 ]
+      focus: [ 66 ]
       for:
-        [0,53,54,55,56,57,58,59,63,64,65,67,68,69,70,71,72,73,74,75,          76
+        [0,52,53,54,55,56,57,58,62,64,65,67,68,69,70,71,72,73,74,75,          76
         ]
       from:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       generated:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       headers: [ 27, 28 ]
-      headers.: [ 28 ]
+      headers.: [ 27 ]
       install:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       install):
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
-      is: [ 51, 60 ]
+      is: [ 51, 66 ]
       kernel32:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,          26
         ]
@@ -877,55 +877,55 @@ indexes:
       mitigations:
         [89,90,91,92,93,94,95,96,97,98,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
         ]
-      on: [ 60, 61, 62 ]
-      on-chip: [ 61, 62 ]
+      on: [ 59, 61, 66 ]
+      on-chip: [ 59, 61 ]
       onecore:
-        [33,37,39,40,41,42,43,44,45,46,47,          48
+        [29,30,31,32,33,34,35,36,37,38,42,          47
         ]
-      onecore): [ 33, 37 ]
-      open: [ 61, 62 ]
+      onecore): [ 42, 47 ]
+      open: [ 59, 61 ]
       projects:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       runtime: [ 27, 28 ]
-      s: [ 52 ]
+      s: [ 60 ]
       sanitizer: [ 1, 2, 3, 4, 5, 6 ]
       sanitizer.: [ 1, 2, 3, 4, 5, 6 ]
-      small: [ 60 ]
+      small: [ 66 ]
       spectre:
-        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,          48
+        [17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,          38
         ]
       spectre):
-        [17,18,19,20,21,22,23,24,25,26,39,40,41,42,43,44,45,46,47,          48
+        [17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,          38
         ]
-      speed: [ 60 ]
-      speed.: [ 60 ]
+      speed: [ 66 ]
+      speed.: [ 66 ]
       standard:
         [7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,          48
         ]
       support:
-        [53,54,55,56,57,58,59,63,64,65,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,62,64,65,67,68,69,70,71,72,73,74,75,          76
         ]
       supporting: [ 1, 2, 3, 4, 5, 6 ]
-      system: [ 60 ]
+      system: [ 66 ]
       targeting:
-        [145,146,147,148,149,150,151,154,157,158,159,162,165,168,171,          174
+        [145,146,147,148,149,150,151,152,153,156,157,160,161,164,165,          168
         ]
       terminal: [ 51 ]
       terminal.: [ 51 ]
       to: [ 51 ]
-      tool: [ 52 ]
-      toolset: [ 63, 64, 65 ]
+      tool: [ 60 ]
+      toolset: [ 62, 64, 65 ]
       use: [ 51 ]
-      v143: [ 63, 64, 65 ]
+      v143: [ 62, 64, 65 ]
       vc:
-        [53,54,55,56,57,58,59,67,68,69,70,71,72,73,74,75,          76
+        [52,53,54,55,56,57,58,67,68,69,70,71,72,73,74,75,          76
         ]
       w:
         [89,90,91,92,93,94,95,96,97,98,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,          140
         ]
-      with: [ 60 ]
-      x64: [ 150, 154, 157, 158 ]
-      x64): [ 150, 154, 157, 158 ]
-      x86: [ 159, 162, 165, 168 ]
-      x86): [ 159, 162, 165, 168 ]
+      with: [ 66 ]
+      x64: [ 151, 152, 153, 156 ]
+      x64): [ 151, 152, 153, 156 ]
+      x86: [ 157, 160, 161, 165 ]
+      x86): [ 157, 160, 161, 165 ]

--- a/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
+++ b/microsoft/msvc/x64_arm/x64_arm-14.29.30037.json
@@ -19,7 +19,7 @@
     "msbuild-properties": {
       "VC_ExecutablePath_x64_arm": "{root}",
       "VCToolArchitecture": "Native64Bit",
-      "VC_ExecutablePath_arm": "$(VC_ExecutablePath_x64_arm);$(VC_ExecutablePath_arm)"
+      "VC_ExecutablePath_arm": "{root};$(VC_ExecutablePath_arm)"
     }
   },
   "demands": {

--- a/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
+++ b/microsoft/msvc/x64_arm64/x64_arm64-14.29.30037.json
@@ -19,7 +19,7 @@
     "msbuild-properties": {
       "VC_ExecutablePath_x64_arm64": "{root}",
       "VCToolArchitecture": "Native64Bit",
-      "VC_ExecutablePath_arm64": "$(VC_ExecutablePath_x64_arm64);$(VC_ExecutablePath_arm64)"
+      "VC_ExecutablePath_arm64": "{root};$(VC_ExecutablePath_arm64)"
     }
   },
   "demands": {

--- a/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
+++ b/microsoft/msvc/x64_x64/x64_x64-14.29.30037.json
@@ -19,7 +19,7 @@
     "msbuild-properties": {
       "VC_ExecutablePath_x64_x64": "{root}",
       "VCToolArchitecture": "Native64Bit",
-      "VC_ExecutablePath_x64": "$(VC_ExecutablePath_x64_x64);$(VC_ExecutablePath_x64)"
+      "VC_ExecutablePath_x64": "{root};$(VC_ExecutablePath_x64)"
     }
   },
   "demands": {

--- a/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
+++ b/microsoft/msvc/x64_x86/x64_x86-14.29.30037.json
@@ -19,7 +19,7 @@
     "msbuild-properties": {
       "VC_ExecutablePath_x64_x86": "{root}",
       "VCToolArchitecture": "Native64Bit",
-      "VC_ExecutablePath_x86": "$(VC_ExecutablePath_x64_x86);;$(VC_ExecutablePath_x86)"
+      "VC_ExecutablePath_x86": "{root};$(VC_ExecutablePath_x86)"
     }
   },
   "demands": {

--- a/sdks/microsoft/atl-headers/atl-headers-14.28.29914.json
+++ b/sdks/microsoft/atl-headers/atl-headers-14.28.29914.json
@@ -12,7 +12,8 @@
       "include": "."
     },
     "msbuild-properties": {
-      "VC_ATLMFC_IncludePath": "{root}"
+      "VC_ATL_IncludePath": "{root}",
+      "VC_ATLMFC_IncludePath": "{root};$(VC_ATLMFC_IncludePath)"
     }
   },
   "requires": {

--- a/sdks/microsoft/atl-headers/atl-headers-14.29.30037.json
+++ b/sdks/microsoft/atl-headers/atl-headers-14.29.30037.json
@@ -15,8 +15,8 @@
       "include": "."
     },
     "msbuild-properties": {
-      "VC_ATLMFC_IncludePath": "{root}",
-      "VC_ATL_IncludePath": "{root}"
+      "VC_ATL_IncludePath": "{root}",
+      "VC_ATLMFC_IncludePath": "{root};$(VC_ATLMFC_IncludePath)"
     }
   },
   "install": [

--- a/sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json
+++ b/sdks/microsoft/mfc-headers/mfc-headers-14.29.30037.json
@@ -16,7 +16,7 @@
     },
     "msbuild-properties": {
       "VC_MFC_IncludePath": "{root}",
-      "VC_ATLMFC_IncludePath": "$(VC_MFC_IncludePath);$(VC_ATLMFC_IncludePath)"
+      "VC_ATLMFC_IncludePath": "{root};$(VC_ATLMFC_IncludePath)"
     }
   },
   "install": [

--- a/sdks/microsoft/windows/windows-10.0.17763.json
+++ b/sdks/microsoft/windows/windows-10.0.17763.json
@@ -1,4 +1,8 @@
 {
+  "id": "sdks/microsoft/windows",
+  "version": "10.0.17763",
+  "summary": "Microsoft Windows SDK",
+  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
   "contacts": {
     "Mark Levine": {
       "email": "markle@microsoft.com",
@@ -53,6 +57,7 @@
       "KIT_SHARED_IncludePath": "{root}\\c\\Include\\10.0.17763.0\\shared",
       "WinRT_IncludePath": "{root}\\c\\Include\\10.0.17763.0\\winrt",
       "CppWinRT_IncludePath": "{root}\\c\\Include\\10.0.17763.0\\cppwinrt",
+      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_MetadataFoundationPath": "{root}\\c\\References\\10.0.17763.0\\windows.foundation.foundationcontract\\4.0.0.0",
       "WindowsSDK_MetadataPath": "{root}\\c\\References",
       "WindowsSDK_MetadataPathVersioned": "{root}\\c\\References\\\\10.0.17763.0",
@@ -74,15 +79,10 @@
       "UniversalCRT_SourcePath": "{root}\\c\\Source\\10.0.17763.0\\ucrt;",
       "WindowsTargetPlatformVersion": "10.0.17763.0",
       "WindowsSdkDir_10": "WindowsSdkDir_10_not_defined\\",
-      "WindowsSdkDir": "$(WindowsSdkDir_10)",
-      "UCRTContentRoot": "$(_UCRTContentRoot)\\",
+      "WindowsSdkDir": "WindowsSdkDir_10_not_defined\\",
+      "UCRTContentRoot": "UniversalCRTRoot_not_defined\\",
       "UniversalCRTSdkDir_10": "UniversalCRTSdkDir_10_not_defined\\",
-      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_HasVersionedContent": "true"
     }
-  },
-  "id": "sdks/microsoft/windows",
-  "version": "10.0.17763",
-  "summary": "Microsoft Windows SDK",
-  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications."
+  }
 }

--- a/sdks/microsoft/windows/windows-10.0.18362.json
+++ b/sdks/microsoft/windows/windows-10.0.18362.json
@@ -1,4 +1,8 @@
 {
+  "id": "sdks/microsoft/windows",
+  "version": "10.0.18362",
+  "summary": "Microsoft Windows SDK",
+  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
   "contacts": {
     "Mark Levine": {
       "email": "markle@microsoft.com",
@@ -53,6 +57,7 @@
       "KIT_SHARED_IncludePath": "{root}\\c\\Include\\10.0.18362.0\\shared",
       "WinRT_IncludePath": "{root}\\c\\Include\\10.0.18362.0\\winrt",
       "CppWinRT_IncludePath": "{root}\\c\\Include\\10.0.18362.0\\cppwinrt",
+      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_MetadataFoundationPath": "{root}\\c\\References\\10.0.18362.0\\windows.foundation.foundationcontract\\4.0.0.0",
       "WindowsSDK_MetadataPath": "{root}\\c\\References",
       "WindowsSDK_MetadataPathVersioned": "{root}\\c\\References\\\\10.0.18362.0",
@@ -74,15 +79,10 @@
       "UniversalCRT_SourcePath": "{root}\\c\\Source\\10.0.18362.0\\ucrt;",
       "WindowsTargetPlatformVersion": "10.0.18362.0",
       "WindowsSdkDir_10": "WindowsSdkDir_10_not_defined\\",
-      "WindowsSdkDir": "$(WindowsSdkDir_10)",
-      "UCRTContentRoot": "$(_UCRTContentRoot)\\",
+      "WindowsSdkDir": "WindowsSdkDir_10_not_defined\\",
+      "UCRTContentRoot": "UniversalCRTRoot_not_defined\\",
       "UniversalCRTSdkDir_10": "UniversalCRTSdkDir_10_not_defined\\",
-      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_HasVersionedContent": "true"
     }
-  },
-  "id": "sdks/microsoft/windows",
-  "version": "10.0.18362",
-  "summary": "Microsoft Windows SDK",
-  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications."
+  }
 }

--- a/sdks/microsoft/windows/windows-10.0.19041.json
+++ b/sdks/microsoft/windows/windows-10.0.19041.json
@@ -1,4 +1,8 @@
 {
+  "id": "sdks/microsoft/windows",
+  "version": "10.0.19041",
+  "summary": "Microsoft Windows SDK",
+  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
   "contacts": {
     "Mark Levine": {
       "email": "markle@microsoft.com",
@@ -53,6 +57,7 @@
       "KIT_SHARED_IncludePath": "{root}\\c\\Include\\10.0.19041.0\\shared",
       "WinRT_IncludePath": "{root}\\c\\Include\\10.0.19041.0\\winrt",
       "CppWinRT_IncludePath": "{root}\\c\\Include\\10.0.19041.0\\cppwinrt",
+      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_MetadataFoundationPath": "{root}\\c\\References\\10.0.19041.0\\windows.foundation.foundationcontract\\4.0.0.0",
       "WindowsSDK_MetadataPath": "{root}\\c\\References",
       "WindowsSDK_MetadataPathVersioned": "{root}\\c\\References\\\\10.0.19041.0",
@@ -74,15 +79,10 @@
       "UniversalCRT_SourcePath": "{root}\\c\\Source\\10.0.19041.0\\ucrt;",
       "WindowsTargetPlatformVersion": "10.0.19041.0",
       "WindowsSdkDir_10": "WindowsSdkDir_10_not_defined\\",
-      "WindowsSdkDir": "$(WindowsSdkDir_10)",
-      "UCRTContentRoot": "$(_UCRTContentRoot)\\",
+      "WindowsSdkDir": "$(WindowsSdkDir_10_not_defined\\)",
+      "UCRTContentRoot": "UniversalCRTRoot_not_defined\\",
       "UniversalCRTSdkDir_10": "UniversalCRTSdkDir_10_not_defined\\",
-      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_HasVersionedContent": "true"
     }
-  },
-  "id": "sdks/microsoft/windows",
-  "version": "10.0.19041",
-  "summary": "Microsoft Windows SDK",
-  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications."
+  }
 }

--- a/sdks/microsoft/windows/windows-10.0.22621.json
+++ b/sdks/microsoft/windows/windows-10.0.22621.json
@@ -1,4 +1,8 @@
 {
+  "id": "sdks/microsoft/windows",
+  "version": "10.0.22621",
+  "summary": "Microsoft Windows SDK",
+  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications.",
   "contacts": {
     "Mark Levine": {
       "email": "markle@microsoft.com",
@@ -53,6 +57,7 @@
       "KIT_SHARED_IncludePath": "{root}\\c\\Include\\10.0.22621.0\\shared",
       "WinRT_IncludePath": "{root}\\c\\Include\\10.0.22621.0\\winrt",
       "CppWinRT_IncludePath": "{root}\\c\\Include\\10.0.22621.0\\cppwinrt",
+      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_MetadataFoundationPath": "{root}\\c\\References\\10.0.22621.0\\windows.foundation.foundationcontract\\4.0.0.0",
       "WindowsSDK_MetadataPath": "{root}\\c\\References",
       "WindowsSDK_MetadataPathVersioned": "{root}\\c\\References\\\\10.0.22621.0",
@@ -74,15 +79,10 @@
       "UniversalCRT_SourcePath": "{root}\\c\\Source\\10.0.22621.0\\ucrt;",
       "WindowsTargetPlatformVersion": "10.0.22621.0",
       "WindowsSdkDir_10": "WindowsSdkDir_10_not_defined\\",
-      "WindowsSdkDir": "$(WindowsSdkDir_10)",
-      "UCRTContentRoot": "$(_UCRTContentRoot)\\",
+      "WindowsSdkDir": "WindowsSdkDir_10_not_defined\\",
+      "UCRTContentRoot": "UniversalCRTRoot_not_defined\\",
       "UniversalCRTSdkDir_10": "UniversalCRTSdkDir_10_not_defined\\",
-      "WindowsSDK_IncludePath": "$(UM_IncludePath);$(KIT_SHARED_IncludePath);$(WinRT_IncludePath);$(CppWinRT_IncludePath);$(WindowsSDK_IncludePath)",
       "WindowsSDK_HasVersionedContent": "true"
     }
-  },
-  "id": "sdks/microsoft/windows",
-  "version": "10.0.22621",
-  "summary": "Microsoft Windows SDK",
-  "description": "The Windows SDK available as a NuGet package for more seamless acquisition and CI/CD integration. This package is designed for C++ applications."
+  }
 }


### PR DESCRIPTION
The changes in the following files are temporary and need to be reverted after https://github.com/microsoft/vcpkg-tool/pull/690

crts\microsoft\onecore\x64\x64-14.29.30037.json
crts\microsoft\onecore\x86\x86-14.29.30037.json
crts\microsoft\desktop\x64\x64-14.29.30037.json
crts\microsoft\desktop\x86\x86-14.29.30037.json